### PR TITLE
[codex] Read TIFF scale metadata and add test image generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Domain language 記錄在 `CONTEXT.md`，用來固定工程師與開發之間對
 - 左側 File Queue / control panel 與右側 fit-to-window image workspace。
 - Add Images 支援 single 2D TIFF 與 `rosettasciio` 可讀取的 single 2D `.dm3`。
 - 8-bit / 16-bit grayscale TIFF 可加入 queue。
+- TIFF 若有一致的 X/Y resolution metadata，會換算成 metadata `nm / pixel`。
 - RGB/RGBA TIFF 直接轉 grayscale，不顯示 warning。
 - multi-page TIFF / unsupported `.dm3` shape / 3D stack / unreadable image data 在 Add Images 時 skip，不加入 queue。
 - Add Images batch summary 顯示 added / skipped 與原因數量。
@@ -177,6 +178,7 @@ Synthetic image generator 需要產生：
 - `.dm3` parser 先使用 `rosettasciio`，之後依公司實際樣本校正 metadata scale。
 - 如果 `.dm3` metadata scale 讀不到，仍可量測，結果用 px。
 - `.dm3` 讀得到 image data 但讀不到 metadata scale 時，不跳 warning，不阻止 Measure / Export；Result View / Excel 顯示單位 `px`，Trace Sheet 記錄 `scale_source = px`。
+- TIFF resolution metadata 可讀取時會作為 metadata scale；若 X/Y resolution 不一致或缺少 resolution unit，仍可量測並依一般 scale fallback 規則處理。
 - GUI Box Plot 不允許混合 nm 與 px。
 - Excel Summary 不混合 nm 與 px；若同一次 Export 同時有 nm 與 px，依 `unit` 分開統計。
 - Scale 優先序為 metadata scale、per-image manual override、batch manual default、px；metadata scale 不可手動覆寫。

--- a/scripts/generate_ab_group_test_images.py
+++ b/scripts/generate_ab_group_test_images.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import tifffile
+
+
+OUTPUT_DIR = Path.home() / "Desktop" / "ab_group_tif_test_images"
+IMAGE_SIZE = 768
+NM_PER_PX = 0.8
+PIXELS_PER_CM = 10_000_000 / NM_PER_PX
+
+
+@dataclass(frozen=True)
+class IslandSpec:
+    center_x: int
+    top_y: int
+    height: int
+    top_width: int
+    bottom_width: int
+    tilt_px: int = 0
+
+
+@dataclass(frozen=True)
+class ImageSpec:
+    group: str
+    index: int
+    seed: int
+    islands: tuple[IslandSpec, ...]
+    background: int
+    metal: int
+    noise_sigma: float
+    nm_per_px: float = NM_PER_PX
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    specs = _image_specs()
+    manifest_rows: list[dict[str, object]] = []
+
+    for spec in specs:
+        image = _render_image(spec)
+        file_name = f"group_{spec.group.lower()}_{spec.index:02d}.tif"
+        tifffile.imwrite(
+            OUTPUT_DIR / file_name,
+            image,
+            resolution=(PIXELS_PER_CM, PIXELS_PER_CM),
+            resolutionunit="CENTIMETER",
+        )
+        manifest_rows.append(
+            {
+                "file_name": file_name,
+                "group": spec.group,
+                "metal_count": len(spec.islands),
+                "nm_per_px": spec.nm_per_px,
+                "note": "synthetic STEM-like metal islands, top-wide bottom-narrow",
+            }
+        )
+
+    with (OUTPUT_DIR / "manifest.csv").open("w", newline="") as file:
+        writer = csv.DictWriter(
+            file, fieldnames=["file_name", "group", "metal_count", "nm_per_px", "note"]
+        )
+        writer.writeheader()
+        writer.writerows(manifest_rows)
+
+
+def _image_specs() -> list[ImageSpec]:
+    return [
+        ImageSpec(
+            group="A",
+            index=1,
+            seed=101,
+            background=26,
+            metal=208,
+            noise_sigma=4.0,
+            islands=_grid_islands(seed=101, top_width=76, bottom_width=48, height=138),
+        ),
+        ImageSpec(
+            group="A",
+            index=2,
+            seed=102,
+            background=27,
+            metal=214,
+            noise_sigma=4.5,
+            islands=_grid_islands(seed=102, top_width=80, bottom_width=50, height=144),
+        ),
+        ImageSpec(
+            group="A",
+            index=3,
+            seed=103,
+            background=25,
+            metal=204,
+            noise_sigma=3.8,
+            islands=_grid_islands(seed=103, top_width=72, bottom_width=46, height=136),
+        ),
+        ImageSpec(
+            group="A",
+            index=4,
+            seed=104,
+            background=28,
+            metal=216,
+            noise_sigma=4.2,
+            islands=_grid_islands(seed=104, top_width=78, bottom_width=48, height=142),
+        ),
+        ImageSpec(
+            group="B",
+            index=1,
+            seed=201,
+            background=25,
+            metal=212,
+            noise_sigma=4.0,
+            islands=_grid_islands(seed=201, top_width=104, bottom_width=68, height=154),
+        ),
+        ImageSpec(
+            group="B",
+            index=2,
+            seed=202,
+            background=27,
+            metal=218,
+            noise_sigma=4.8,
+            islands=_grid_islands(seed=202, top_width=110, bottom_width=72, height=160),
+        ),
+        ImageSpec(
+            group="B",
+            index=3,
+            seed=203,
+            background=26,
+            metal=210,
+            noise_sigma=4.3,
+            islands=_grid_islands(seed=203, top_width=100, bottom_width=66, height=150),
+        ),
+        ImageSpec(
+            group="B",
+            index=4,
+            seed=204,
+            background=28,
+            metal=220,
+            noise_sigma=4.5,
+            islands=_grid_islands(seed=204, top_width=106, bottom_width=70, height=156),
+        ),
+    ]
+
+
+def _grid_islands(
+    seed: int, top_width: int, bottom_width: int, height: int
+) -> tuple[IslandSpec, ...]:
+    rng = np.random.default_rng(seed)
+    centers_x = [112, 292, 476, 656]
+    tops_y = [60, 292, 524]
+    islands: list[IslandSpec] = []
+    for row_index, top_y in enumerate(tops_y):
+        for column_index, center_x in enumerate(centers_x):
+            islands.append(
+                IslandSpec(
+                    center_x=center_x + int(rng.integers(-14, 15)),
+                    top_y=top_y + int(rng.integers(-12, 13)),
+                    height=height + int(rng.integers(-8, 9)),
+                    top_width=top_width + int(rng.integers(-6, 7)),
+                    bottom_width=bottom_width + int(rng.integers(-5, 6)),
+                    tilt_px=int(rng.integers(-7, 8)),
+                )
+            )
+    return tuple(islands)
+
+
+def _render_image(spec: ImageSpec) -> np.ndarray:
+    rng = np.random.default_rng(spec.seed)
+    image = rng.normal(
+        loc=spec.background,
+        scale=spec.noise_sigma,
+        size=(IMAGE_SIZE, IMAGE_SIZE),
+    )
+    image += _low_frequency_texture(rng) * 5.0
+
+    for island in spec.islands:
+        _draw_island(image, island, spec.metal, rng)
+
+    _add_faint_scan_lines(image, rng)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _draw_island(
+    image: np.ndarray, island: IslandSpec, metal_intensity: int, rng: np.random.Generator
+) -> None:
+    edge_walk = rng.normal(0.0, 1.0, island.height + 2).cumsum()
+    edge_walk -= edge_walk.mean()
+    edge_walk = np.clip(edge_walk, -5.0, 5.0)
+
+    for row_offset in range(island.height):
+        y = island.top_y + row_offset
+        if y < 0 or y >= image.shape[0]:
+            continue
+
+        fraction = row_offset / max(1, island.height - 1)
+        width = island.top_width + (island.bottom_width - island.top_width) * fraction
+        width += 2.0 * np.sin(fraction * np.pi * 2.0 + island.center_x / 37.0)
+        center = island.center_x + round(island.tilt_px * (fraction - 0.5))
+        edge_noise = edge_walk[row_offset]
+        left = round(center - width / 2 + edge_noise)
+        right = round(center + width / 2 + edge_noise * 0.4)
+        left = max(0, left)
+        right = min(image.shape[1], right)
+        if right <= left:
+            continue
+
+        row_noise = rng.normal(0.0, 3.0, right - left)
+        image[y, left:right] = metal_intensity + row_noise
+
+        if left > 0:
+            image[y, left - 1] = (image[y, left - 1] + metal_intensity) / 2
+        if right < image.shape[1]:
+            image[y, right] = (image[y, right] + metal_intensity) / 2
+
+
+def _low_frequency_texture(rng: np.random.Generator) -> np.ndarray:
+    coarse_size = 32
+    tile_size = int(np.ceil(IMAGE_SIZE / coarse_size))
+    coarse = rng.normal(0.0, 1.0, size=(coarse_size, coarse_size))
+    return np.kron(coarse, np.ones((tile_size, tile_size)))[:IMAGE_SIZE, :IMAGE_SIZE]
+
+
+def _add_faint_scan_lines(image: np.ndarray, rng: np.random.Generator) -> None:
+    for y in range(0, image.shape[0], 16):
+        image[y : y + 1, :] += rng.normal(0.0, 1.5)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/measurer/image_queue.py
+++ b/src/measurer/image_queue.py
@@ -266,23 +266,53 @@ class ImageQueue:
 def _read_image(path: Path) -> LoadedImage:
     if path.suffix.lower() == ".dm3":
         return _read_dm3_image(path)
-    return LoadedImage(image=_read_tiff_image(path))
+    return _read_tiff_image(path)
 
 
-def _read_tiff_image(path: Path) -> np.ndarray:
+def _read_tiff_image(path: Path) -> LoadedImage:
     with tifffile.TiffFile(path) as tiff:
         if len(tiff.pages) != 1:
-            return np.asarray([])
+            return LoadedImage(image=np.asarray([]))
         page = tiff.pages[0]
         image = tiff.asarray()
+        metadata_nm_per_px = _metadata_nm_per_px_from_tiff_page(page)
 
     if (
         image.ndim == 3
         and image.shape[-1] in (3, 4)
         and page.samplesperpixel in (3, 4)
     ):
-        return _to_grayscale(image)
-    return image
+        image = _to_grayscale(image)
+    return LoadedImage(image=image, metadata_nm_per_px=metadata_nm_per_px)
+
+
+def _metadata_nm_per_px_from_tiff_page(page: tifffile.TiffPage) -> float | None:
+    try:
+        resolution_unit = int(page.tags["ResolutionUnit"].value)
+        x_resolution = _ratio_to_float(page.tags["XResolution"].value)
+        y_resolution = _ratio_to_float(page.tags["YResolution"].value)
+    except (KeyError, TypeError, ValueError, ZeroDivisionError):
+        return None
+
+    if x_resolution <= 0 or y_resolution <= 0:
+        return None
+    if not np.allclose([x_resolution, y_resolution], x_resolution):
+        return None
+
+    if resolution_unit == 2:
+        nm_per_unit = 25_400_000.0
+    elif resolution_unit == 3:
+        nm_per_unit = 10_000_000.0
+    else:
+        return None
+    return nm_per_unit / x_resolution
+
+
+def _ratio_to_float(value: object) -> float:
+    if isinstance(value, tuple) and len(value) == 2:
+        numerator, denominator = value
+        return float(numerator) / float(denominator)
+    return float(value)
 
 
 def _read_dm3_image(path: Path) -> LoadedImage:

--- a/tests/test_image_queue.py
+++ b/tests/test_image_queue.py
@@ -152,6 +152,27 @@ def test_add_images_accepts_valid_2d_tiff(tmp_path):
     assert row.image.shape == (4, 4)
 
 
+def test_add_images_reads_tiff_centimeter_resolution_as_nm_per_px(tmp_path):
+    image_path = tmp_path / "metadata_scale.tif"
+    image = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    nm_per_px = 0.8
+    pixels_per_cm = 10_000_000 / nm_per_px
+    tifffile.imwrite(
+        image_path,
+        image,
+        resolution=(pixels_per_cm, pixels_per_cm),
+        resolutionunit="CENTIMETER",
+    )
+
+    queue = ImageQueue()
+    summary = queue.add_images([image_path])
+
+    assert summary.added_count == 1
+    assert queue.resolve_scale(0) == ScaleResolution(
+        source="metadata", nm_per_px=0.8
+    )
+
+
 def test_add_images_converts_rgb_tiff_to_grayscale(tmp_path):
     image_path = tmp_path / "rgb_stem_zc.tif"
     rgb = np.zeros((3, 2, 3), dtype=np.uint8)


### PR DESCRIPTION
## What changed

- Read TIFF `XResolution` / `YResolution` metadata as `nm / pixel` when the resolution unit is inch or centimeter and X/Y resolution match.
- Add regression coverage for TIFF centimeter resolution metadata.
- Add a generator script for a desktop A/B group TIFF test set with 12 top-wide bottom-narrow metal islands per image and embedded `0.8 nm/px` metadata.
- Update README to document TIFF resolution metadata fallback behavior.

## Why

The generated A/B group images need to be real `.tif` files with `nm/px` metadata so they can exercise the same metadata path as user-loaded images. The app previously only resolved metadata scale from `.dm3` inputs.

## Validation

- `uv run pytest` — 88 passed
- Loaded `/Users/lesterc/Desktop/ab_group_tif_test_images/*.tif` through `ImageQueue`: 8 images, all `metadata 0.8`
- Measured all 8 desktop TIFFs successfully: 12 metal islands detected per image