### PR TITLE
[codex] Refactor measurement reporting modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ assets/icons/measurer.ico
 - incomplete polygon drawing 不會加入 ROI Union，也不會影響 Measure Current。
 - Original / Debug workspace 會顯示既有 ROI；拖選 rectangle 或繪製 polygon 時會顯示 cyan outline，不用實心色塊蓋住影像。
 - Image workspace 會等比例 fit 影像，不讓大型原始影像的 pixmap size 撐壞視窗比例。
+- Original preview、Result Image 與 Debug Image 共用同一套 grayscale display normalization，避免 GUI 預覽與匯出圖片亮度轉換規則分歧。
 - Undo ROI 會移除最近完成的 ROI Shape，不論是 rectangle 或 polygon；Undo 到沒有 ROI Shapes 時回到 Full image。
 - Clear ROI 會回到 Full image。
 - ROI geometry 會 clamp 在 image bounds 內。
+- ROI Union 幾何規則集中在獨立 module，Image Queue、Measure Current、Result / Debug display 與 Export 共用同一套 rectangle / polygon ROI Shape clamp、bounding box、mask 與 area 計算。
 - ROI 改變、Undo ROI 或 Clear ROI 會刪除 stale measurement results，Measure 回到 `Pending`，Export 回到 `Not exported`。
 - Measure Current 支援 clean synthetic STEM ZC Image 中多個 bright Metal Islands on dark LK 的 tracer bullet。
 - Measure Current 只量測目前選取圖片，不自動切下一張，也不直接寫 output files。
@@ -71,9 +73,11 @@ assets/icons/measurer.ico
 - Result View 的 Measurement Lines / values 由 canvas 依目前顯示尺寸繪製，不把文字先畫進原始影像 pixmap 再放大。
 - Result View 下方 summary 依 measurement type 彙整 value range 與 count，避免多 Metal Islands 時把每一筆完整名稱串成難讀長句。
 - Result View 使用固定 measurement type 顏色：TCD cyan、BCD orange、Height yellow、Horizontal Space magenta、Vertical Space lime。
+- Result View、Box Plot preview 與 Export 目前共用同一組 measurement type 順序、target ID 解析、scale label、summary 與顏色定義，避免 GUI 與匯出結果對 TCD / BCD / Height / Horizontal Space / Vertical Space 的呈現規則分歧。
 - Result View 數值文字顯示在線段中心附近，使用白字加 dark outline，會 clamp 在 image bounds 內，並用固定上下偏移減少局部碰撞；若仍重疊，不讓 rendering failed。
 - batch manual default 或單張 manual override 改變後，Result View 會用現有 px geometry 重新換算顯示值與單位，不需要重測。
 - Box Plot preview 已可從 GUI 切換，會依 Group 與 measurement type 彙整 successful final measurements，使用 canvas 依目前顯示尺寸繪製 raw points with jitter、左側 y-axis 刻度與 summary/status panel；x-axis 先依 measurement type 分群，再在群內並排各 Group 方便比較。
+- Box Plot preview 的資料點整理、unit 混用檢查、bucket 排序、摘要文字與 percentile/tick 計算集中在獨立 module；GUI 只負責依這些結果繪製畫面。
 - Box Plot preview 提供 All 與 TCD / BCD / Height / Horizontal Space / Vertical Space checkbox，可只顯示勾選的 measurement types；切換 checkbox 會用現有 results 立即刷新，不需要重測。
 - Group、batch manual default 或單張 manual override 改變後，Box Plot preview 會重新聚合現有 measurement results，不需要重測。
 - Box Plot preview 不混合 nm 與 px；同時存在 nm 與 px measurement results 時，顯示 warning 而不畫 mixed-unit plot。

--- a/src/measurer/app.py
+++ b/src/measurer/app.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import sys
 from pathlib import Path
 
@@ -28,46 +27,39 @@ from PySide6.QtWidgets import (
 )
 
 from measurer.app_icon import load_application_icon
+from measurer.box_plot import (
+    BoxPlotPoint,
+    box_plot_buckets,
+    box_plot_label_clusters,
+    box_plot_points,
+    box_plot_ticks,
+    box_plot_y,
+    format_box_plot_summary,
+    percentile,
+)
 from measurer.export import OverwriteSummary, export_measured_batch
+from measurer.image_display import normalize_to_uint8
 from measurer.image_queue import (
     AddImagesSummary,
     ImageQueue,
-    PolygonRoi,
-    RectRoi,
-    RoiSelection,
 )
-from measurer.image_queue import roi_union_area_px
 from measurer.measurement import (
     HARD_MIN_COMPONENT_AREA_PX,
-    Measurement,
     MeasurementResult,
     measure_image,
 )
-
-
-MEASUREMENT_TYPE_ORDER = [
-    "TCD",
-    "BCD",
-    "Height",
-    "Horizontal Space",
-    "Vertical Space",
-]
+from measurer.measurement_report import (
+    MEASUREMENT_TYPE_COLORS,
+    MEASUREMENT_TYPE_ORDER,
+    format_measurement_summary,
+    successful_measurement_report_items,
+)
+from measurer.roi import PolygonRoi, RectRoi, RoiSelection, roi_union_area_px
 
 MEASUREMENT_COLORS = {
-    "TCD": QColor(64, 196, 255),
-    "BCD": QColor(255, 183, 77),
-    "Height": QColor(255, 210, 64),
-    "Horizontal Space": QColor(186, 104, 200),
-    "Vertical Space": QColor(129, 199, 132),
+    measurement_type: QColor(*rgb)
+    for measurement_type, rgb in MEASUREMENT_TYPE_COLORS.items()
 }
-
-
-@dataclass(frozen=True)
-class BoxPlotPoint:
-    group: str
-    measurement_type: str
-    value: float
-    unit: str
 
 
 class ImageCanvas(QWidget):
@@ -346,16 +338,12 @@ class ImageCanvas(QWidget):
     def _draw_measurement_overlay(
         self, painter: QPainter, result: MeasurementResult
     ) -> None:
-        unit = "px" if self._measurement_nm_per_px is None else "nm"
-        scale = 1.0 if self._measurement_nm_per_px is None else self._measurement_nm_per_px
         placed_label_rects: list[QRect] = []
-        for measurement in result.measurements.values():
-            if measurement.status != "success":
-                continue
-            measurement_type = _measurement_type(measurement)
-            if measurement_type is None:
-                continue
-            color = MEASUREMENT_COLORS[measurement_type]
+        for item in successful_measurement_report_items(
+            result, self._measurement_nm_per_px
+        ):
+            measurement = item.measurement
+            color = QColor(*item.color_rgb)
             start = self._image_to_widget_point(
                 measurement.line.start.x, measurement.line.start.y
             )
@@ -365,10 +353,9 @@ class ImageCanvas(QWidget):
             painter.setPen(QPen(color, 2))
             painter.drawLine(start, end)
 
-            label = f"{measurement.value_px * scale:.1f} {unit}"
             label_rect = _result_label_rect(
                 painter=painter,
-                text=label,
+                text=item.label,
                 center_x=round((start.x() + end.x()) / 2),
                 center_y=round((start.y() + end.y()) / 2),
                 image_width=self.width(),
@@ -376,7 +363,7 @@ class ImageCanvas(QWidget):
                 placed_rects=placed_label_rects,
             )
             placed_label_rects.append(label_rect)
-            _draw_outlined_text(painter, label_rect, label)
+            _draw_outlined_text(painter, label_rect, item.label)
 
     def _image_to_widget_point(self, x: int, y: int) -> QPoint:
         image_rect = self._image_rect()
@@ -407,7 +394,7 @@ class ImageCanvas(QWidget):
             min_value -= 1
             max_value += 1
 
-        ticks = _box_plot_ticks(min_value, max_value)
+        ticks = box_plot_ticks(min_value, max_value)
         metrics = painter.fontMetrics()
         tick_label_width = max(
             metrics.horizontalAdvance(f"{tick:.1f}") for tick in ticks
@@ -420,7 +407,7 @@ class ImageCanvas(QWidget):
             return
 
         for tick in ticks:
-            y = _box_plot_y(tick, min_value, max_value, top, bottom)
+            y = box_plot_y(tick, min_value, max_value, top, bottom)
             label = f"{tick:.1f}"
             painter.setPen(QPen(QColor(43, 51, 63), 1))
             painter.drawLine(left, y, right, y)
@@ -436,7 +423,7 @@ class ImageCanvas(QWidget):
         painter.drawLine(left, bottom, right, bottom)
         painter.drawLine(left, top, left, bottom)
 
-        buckets = _box_plot_buckets(points)
+        buckets = box_plot_buckets(points)
         bucket_count = len(buckets)
         bucket_width = (right - left) / max(1, bucket_count)
         for bucket_index, ((group, measurement_type), bucket_values) in enumerate(buckets):
@@ -445,14 +432,14 @@ class ImageCanvas(QWidget):
             sorted_values = sorted(bucket_values)
             low = sorted_values[0]
             high = sorted_values[-1]
-            q1 = _percentile(sorted_values, 25)
-            median = _percentile(sorted_values, 50)
-            q3 = _percentile(sorted_values, 75)
-            low_y = _box_plot_y(low, min_value, max_value, top, bottom)
-            high_y = _box_plot_y(high, min_value, max_value, top, bottom)
-            q1_y = _box_plot_y(q1, min_value, max_value, top, bottom)
-            median_y = _box_plot_y(median, min_value, max_value, top, bottom)
-            q3_y = _box_plot_y(q3, min_value, max_value, top, bottom)
+            q1 = percentile(sorted_values, 25)
+            median = percentile(sorted_values, 50)
+            q3 = percentile(sorted_values, 75)
+            low_y = box_plot_y(low, min_value, max_value, top, bottom)
+            high_y = box_plot_y(high, min_value, max_value, top, bottom)
+            q1_y = box_plot_y(q1, min_value, max_value, top, bottom)
+            median_y = box_plot_y(median, min_value, max_value, top, bottom)
+            q3_y = box_plot_y(q3, min_value, max_value, top, bottom)
 
             painter.setPen(QPen(color, 2))
             painter.setBrush(Qt.BrushStyle.NoBrush)
@@ -462,7 +449,7 @@ class ImageCanvas(QWidget):
             painter.setBrush(color)
             for point_index, value in enumerate(bucket_values):
                 jitter = ((point_index % 5) - 2) * 4
-                y = _box_plot_y(value, min_value, max_value, top, bottom)
+                y = box_plot_y(value, min_value, max_value, top, bottom)
                 painter.drawEllipse(center_x + jitter - 2, y - 2, 4, 4)
 
             painter.setPen(QPen(QColor(220, 226, 235), 1))
@@ -474,7 +461,7 @@ class ImageCanvas(QWidget):
                 group_label,
             )
 
-        for measurement_type, start_index, end_index in _box_plot_label_clusters(buckets):
+        for measurement_type, start_index, end_index in box_plot_label_clusters(buckets):
             cluster_left = left + bucket_width * start_index
             cluster_right = left + bucket_width * (end_index + 1)
             cluster_center_x = round((cluster_left + cluster_right) / 2)
@@ -920,11 +907,11 @@ class MeasurerWindow(QMainWindow):
         self._sync_view_buttons()
 
     def _show_box_plot_view(self) -> None:
-        points, warning = _box_plot_points(
+        points, warning = box_plot_points(
             self.queue, self._selected_box_plot_measurement_types()
         )
         self.image_label.set_box_plot(points, warning)
-        self.result_values_label.setText(_format_box_plot_summary(points, warning))
+        self.result_values_label.setText(format_box_plot_summary(points, warning))
         self.current_view_mode = "Box Plot"
         self._sync_view_buttons()
 
@@ -1101,7 +1088,7 @@ def _roi_is_too_small(roi: RoiSelection, image: np.ndarray) -> bool:
 
 
 def _array_to_pixmap(image: np.ndarray) -> QPixmap:
-    display = _normalize_to_uint8(image)
+    display = normalize_to_uint8(image)
     height, width = display.shape
     bytes_per_line = display.strides[0]
     qimage = QImage(
@@ -1175,7 +1162,7 @@ def _draw_outlined_text(painter: QPainter, label_rect: QRect, text: str) -> None
 
 
 def _debug_to_pixmap(image: np.ndarray, result: MeasurementResult) -> QPixmap:
-    display = _normalize_to_uint8(image)
+    display = normalize_to_uint8(image)
     height, width = display.shape
     rgb = np.ascontiguousarray(np.dstack([display, display, display]))
     if result.detection is not None:
@@ -1258,33 +1245,7 @@ def _draw_component_boxes(
 def _format_result_values(
     result: MeasurementResult, nm_per_px: float | None
 ) -> str:
-    unit = "px" if nm_per_px is None else "nm"
-    scale = 1.0 if nm_per_px is None else nm_per_px
-    values_by_type: dict[str, list[float]] = {
-        measurement_type: [] for measurement_type in MEASUREMENT_TYPE_ORDER
-    }
-    for measurement in result.measurements.values():
-        if measurement.status != "success":
-            continue
-        measurement_type = _measurement_type(measurement)
-        if measurement_type is None:
-            continue
-        values_by_type[measurement_type].append(measurement.value_px * scale)
-
-    parts = []
-    for measurement_type in MEASUREMENT_TYPE_ORDER:
-        values = values_by_type[measurement_type]
-        if not values:
-            continue
-        minimum = min(values)
-        maximum = max(values)
-        value_label = (
-            f"{minimum:.1f}"
-            if minimum == maximum
-            else f"{minimum:.1f}-{maximum:.1f}"
-        )
-        parts.append(f"{measurement_type}: {value_label} {unit} (n={len(values)})")
-    return " | ".join(parts)
+    return format_measurement_summary(result, nm_per_px)
 
 
 def _format_overwrite_dialog_text(summary: OverwriteSummary) -> str:
@@ -1313,146 +1274,10 @@ def _pluralize(count: int, singular: str) -> str:
     return singular if count == 1 else f"{singular}s"
 
 
-def _box_plot_points(
-    queue: ImageQueue, selected_measurement_types: set[str] | None = None
-) -> tuple[list[BoxPlotPoint], str]:
-    if selected_measurement_types is not None and not selected_measurement_types:
-        return [], "Box Plot: no selected measurement types."
-
-    points: list[BoxPlotPoint] = []
-    units: set[str] = set()
-    for row_index, row in enumerate(queue.rows):
-        if row.measure_status != "Measured":
-            continue
-        if not isinstance(row.measurement_results, MeasurementResult):
-            continue
-
-        scale_resolution = queue.resolve_scale(row_index)
-        unit = "px" if scale_resolution.nm_per_px is None else "nm"
-        scale = 1.0 if scale_resolution.nm_per_px is None else scale_resolution.nm_per_px
-        row_has_visible_measurement = False
-        for measurement in row.measurement_results.measurements.values():
-            if measurement.status != "success":
-                continue
-            measurement_type = _measurement_type(measurement)
-            if measurement_type is None:
-                continue
-            if (
-                selected_measurement_types is not None
-                and measurement_type not in selected_measurement_types
-            ):
-                continue
-            row_has_visible_measurement = True
-            points.append(
-                BoxPlotPoint(
-                    group=row.group,
-                    measurement_type=measurement_type,
-                    value=measurement.value_px * scale,
-                    unit=unit,
-                )
-            )
-        if row_has_visible_measurement:
-            units.add(unit)
-
-    if len(units) > 1:
-        return points, "Box Plot cannot mix nm and px measurements."
-    return points, ""
-
-
-def _measurement_type(measurement: Measurement) -> str | None:
-    for measurement_type in sorted(MEASUREMENT_TYPE_ORDER, key=len, reverse=True):
-        if measurement.name.endswith(measurement_type):
-            return measurement_type
-    return None
-
-
-def _format_box_plot_summary(points: list[BoxPlotPoint], warning: str) -> str:
-    if warning:
-        return warning
-    if not points:
-        return "Box Plot: no measured data."
-
-    groups = ", ".join(sorted({point.group for point in points}))
-    types = ", ".join(
-        measurement_type
-        for measurement_type in MEASUREMENT_TYPE_ORDER
-        if any(point.measurement_type == measurement_type for point in points)
-    )
-    unit = points[0].unit
-    count = len(points)
-    label = "measurement" if count == 1 else "measurements"
-    return (
-        f"Box Plot: {count} {label} | Unit: {unit} | "
-        f"Groups: {groups} | Types: {types}"
-    )
-
-
-def _box_plot_buckets(
-    points: list[BoxPlotPoint],
-) -> list[tuple[tuple[str, str], list[float]]]:
-    grouped: dict[tuple[str, str], list[float]] = {}
-    for point in points:
-        grouped.setdefault((point.group, point.measurement_type), []).append(point.value)
-    return sorted(
-        grouped.items(),
-        key=lambda item: (
-            MEASUREMENT_TYPE_ORDER.index(item[0][1]),
-            item[0][0],
-        ),
-    )
-
-
-def _box_plot_label_clusters(
-    buckets: list[tuple[tuple[str, str], list[float]]],
-) -> list[tuple[str, int, int]]:
-    clusters: list[tuple[str, int, int]] = []
-    if not buckets:
-        return clusters
-
-    current_type = buckets[0][0][1]
-    start_index = 0
-    for index, ((_group, measurement_type), _values) in enumerate(buckets[1:], start=1):
-        if measurement_type == current_type:
-            continue
-        clusters.append((current_type, start_index, index - 1))
-        current_type = measurement_type
-        start_index = index
-    clusters.append((current_type, start_index, len(buckets) - 1))
-    return clusters
-
-
-def _box_plot_y(
-    value: float, min_value: float, max_value: float, top: int, bottom: int
-) -> int:
-    fraction = (value - min_value) / (max_value - min_value)
-    return round(bottom - fraction * (bottom - top))
-
-
-def _box_plot_ticks(
-    min_value: float, max_value: float, tick_count: int = 5
-) -> list[float]:
-    if tick_count <= 1:
-        return [min_value]
-    step = (max_value - min_value) / (tick_count - 1)
-    return [min_value + step * index for index in range(tick_count)]
-
-
 def _elided_center_label(metrics, text: str, max_width: int) -> str:
     if max_width <= 0:
         return ""
     return metrics.elidedText(text, Qt.TextElideMode.ElideRight, max_width)
-
-
-def _percentile(sorted_values: list[float], percentile: float) -> float:
-    if len(sorted_values) == 1:
-        return sorted_values[0]
-    position = (len(sorted_values) - 1) * percentile / 100
-    lower = int(np.floor(position))
-    upper = int(np.ceil(position))
-    if lower == upper:
-        return sorted_values[lower]
-    weight = position - lower
-    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
 
 
 def _format_debug_values(result: MeasurementResult) -> str:
@@ -1492,16 +1317,6 @@ def _format_debug_values(result: MeasurementResult) -> str:
             f"Fallback ratio: {fallback_ratio * 100:.1f}%",
         ]
     )
-
-
-def _normalize_to_uint8(image: np.ndarray) -> np.ndarray:
-    if image.dtype == np.uint8:
-        return np.ascontiguousarray(image)
-    max_value = float(np.max(image))
-    if max_value <= 0:
-        return np.zeros(image.shape, dtype=np.uint8)
-    scaled = np.asarray(image, dtype=np.float32) / max_value * 255
-    return np.ascontiguousarray(np.rint(scaled).astype(np.uint8))
 
 
 def _stylesheet() -> str:

--- a/src/measurer/box_plot.py
+++ b/src/measurer/box_plot.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import ceil, floor
+
+from measurer.image_queue import ImageQueue
+from measurer.measurement import MeasurementResult
+from measurer.measurement_report import MEASUREMENT_TYPE_ORDER, measurement_report_key
+
+
+@dataclass(frozen=True)
+class BoxPlotPoint:
+    group: str
+    measurement_type: str
+    value: float
+    unit: str
+
+
+def box_plot_points(
+    queue: ImageQueue, selected_measurement_types: set[str] | None = None
+) -> tuple[list[BoxPlotPoint], str]:
+    if selected_measurement_types is not None and not selected_measurement_types:
+        return [], "Box Plot: no selected measurement types."
+
+    points: list[BoxPlotPoint] = []
+    units: set[str] = set()
+    for row_index, row in enumerate(queue.rows):
+        if row.measure_status != "Measured":
+            continue
+        if not isinstance(row.measurement_results, MeasurementResult):
+            continue
+
+        scale_resolution = queue.resolve_scale(row_index)
+        unit = "px" if scale_resolution.nm_per_px is None else "nm"
+        scale = 1.0 if scale_resolution.nm_per_px is None else scale_resolution.nm_per_px
+        row_has_visible_measurement = False
+        for measurement in row.measurement_results.measurements.values():
+            if measurement.status != "success":
+                continue
+            report_key = measurement_report_key(measurement)
+            if report_key is None:
+                continue
+            measurement_type = report_key.measurement_type
+            if (
+                selected_measurement_types is not None
+                and measurement_type not in selected_measurement_types
+            ):
+                continue
+            row_has_visible_measurement = True
+            points.append(
+                BoxPlotPoint(
+                    group=row.group,
+                    measurement_type=measurement_type,
+                    value=measurement.value_px * scale,
+                    unit=unit,
+                )
+            )
+        if row_has_visible_measurement:
+            units.add(unit)
+
+    if len(units) > 1:
+        return points, "Box Plot cannot mix nm and px measurements."
+    return points, ""
+
+
+def format_box_plot_summary(points: list[BoxPlotPoint], warning: str) -> str:
+    if warning:
+        return warning
+    if not points:
+        return "Box Plot: no measured data."
+
+    groups = ", ".join(sorted({point.group for point in points}))
+    types = ", ".join(
+        measurement_type
+        for measurement_type in MEASUREMENT_TYPE_ORDER
+        if any(point.measurement_type == measurement_type for point in points)
+    )
+    unit = points[0].unit
+    count = len(points)
+    label = "measurement" if count == 1 else "measurements"
+    return (
+        f"Box Plot: {count} {label} | Unit: {unit} | "
+        f"Groups: {groups} | Types: {types}"
+    )
+
+
+def box_plot_buckets(
+    points: list[BoxPlotPoint],
+) -> list[tuple[tuple[str, str], list[float]]]:
+    grouped: dict[tuple[str, str], list[float]] = {}
+    for point in points:
+        grouped.setdefault((point.group, point.measurement_type), []).append(point.value)
+    return sorted(
+        grouped.items(),
+        key=lambda item: (
+            MEASUREMENT_TYPE_ORDER.index(item[0][1]),
+            item[0][0],
+        ),
+    )
+
+
+def box_plot_label_clusters(
+    buckets: list[tuple[tuple[str, str], list[float]]],
+) -> list[tuple[str, int, int]]:
+    clusters: list[tuple[str, int, int]] = []
+    if not buckets:
+        return clusters
+
+    current_type = buckets[0][0][1]
+    start_index = 0
+    for index, ((_group, measurement_type), _values) in enumerate(buckets[1:], start=1):
+        if measurement_type == current_type:
+            continue
+        clusters.append((current_type, start_index, index - 1))
+        current_type = measurement_type
+        start_index = index
+    clusters.append((current_type, start_index, len(buckets) - 1))
+    return clusters
+
+
+def box_plot_y(
+    value: float, min_value: float, max_value: float, top: int, bottom: int
+) -> int:
+    fraction = (value - min_value) / (max_value - min_value)
+    return round(bottom - fraction * (bottom - top))
+
+
+def box_plot_ticks(
+    min_value: float, max_value: float, tick_count: int = 5
+) -> list[float]:
+    if tick_count <= 1:
+        return [min_value]
+    step = (max_value - min_value) / (tick_count - 1)
+    return [min_value + step * index for index in range(tick_count)]
+
+
+def percentile(sorted_values: list[float], percentile_value: float) -> float:
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = (len(sorted_values) - 1) * percentile_value / 100
+    lower = floor(position)
+    upper = ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = position - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight

--- a/src/measurer/export.py
+++ b/src/measurer/export.py
@@ -9,31 +9,21 @@ from openpyxl import Workbook
 from PySide6.QtGui import QColor, QImage, QPainter, QPen
 from PySide6.QtWidgets import QApplication
 
-from measurer.image_queue import ImageQueue, RoiSelection
+from measurer.image_display import normalize_to_uint8
+from measurer.image_queue import ImageQueue
 from measurer.measurement import Measurement, MeasurementResult
+from measurer.measurement_report import (
+    MEASUREMENT_TYPE_ORDER,
+    measurement_report_key,
+    successful_measurement_report_items,
+)
+from measurer.roi import RoiSelection
 
 
 NO_MEASURED_IMAGES_MESSAGE = "No measured images to export."
 MULTI_SOURCE_OUTPUT_FOLDER_MESSAGE = "Choose an output folder for multi-source export."
 OVERWRITE_CONFIRMATION_MESSAGE = "Confirm overwrite to export."
 _QAPPLICATION: QApplication | None = None
-
-MEASUREMENT_TYPE_ORDER = [
-    "TCD",
-    "BCD",
-    "Height",
-    "Horizontal Space",
-    "Vertical Space",
-]
-
-MEASUREMENT_COLORS = {
-    "TCD": QColor(64, 196, 255),
-    "BCD": QColor(255, 183, 77),
-    "Height": QColor(255, 210, 64),
-    "Horizontal Space": QColor(186, 104, 200),
-    "Vertical Space": QColor(129, 199, 132),
-}
-
 
 @dataclass(frozen=True)
 class OverwriteSummary:
@@ -267,10 +257,11 @@ def _write_workbook(queue: ImageQueue, output_path: Path) -> None:
         unit = "px" if scale_resolution.nm_per_px is None else "nm"
         scale = 1.0 if scale_resolution.nm_per_px is None else scale_resolution.nm_per_px
         for measurement in result.measurements.values():
-            measurement_type = _measurement_type(measurement)
-            if measurement_type is None:
+            report_key = measurement_report_key(measurement)
+            if report_key is None:
                 continue
-            target_id = _target_id(measurement, measurement_type)
+            measurement_type = report_key.measurement_type
+            target_id = report_key.target_id
             value = (
                 None
                 if measurement.status != "success"
@@ -414,15 +405,9 @@ def _fallback_ratio(refined_count: int, fallback_count: int) -> float | None:
 def _draw_measurement_lines(
     painter: QPainter, result: MeasurementResult, nm_per_px: float | None
 ) -> None:
-    unit = "px" if nm_per_px is None else "nm"
-    scale = 1.0 if nm_per_px is None else nm_per_px
-    for measurement in result.measurements.values():
-        if measurement.status != "success":
-            continue
-        measurement_type = _measurement_type(measurement)
-        if measurement_type is None:
-            continue
-        painter.setPen(QPen(MEASUREMENT_COLORS[measurement_type], 2))
+    for item in successful_measurement_report_items(result, nm_per_px):
+        measurement = item.measurement
+        painter.setPen(QPen(QColor(*item.color_rgb), 2))
         painter.drawLine(
             measurement.line.start.x,
             measurement.line.start.y,
@@ -433,7 +418,7 @@ def _draw_measurement_lines(
         painter.drawText(
             round((measurement.line.start.x + measurement.line.end.x) / 2),
             round((measurement.line.start.y + measurement.line.end.y) / 2),
-            f"{measurement.value_px * scale:.1f} {unit}",
+            item.label,
         )
 
 
@@ -478,7 +463,7 @@ def _component_qimage(image: np.ndarray, result: MeasurementResult) -> QImage:
 
 
 def _rgb_qimage(image: np.ndarray) -> QImage:
-    display = _normalize_to_uint8(image)
+    display = normalize_to_uint8(image)
     height, width = display.shape
     rgb = np.ascontiguousarray(np.dstack([display, display, display]))
     return QImage(
@@ -488,28 +473,6 @@ def _rgb_qimage(image: np.ndarray) -> QImage:
         width * 3,
         QImage.Format.Format_RGB888,
     ).copy()
-
-
-def _normalize_to_uint8(image: np.ndarray) -> np.ndarray:
-    if image.dtype == np.uint8:
-        return np.ascontiguousarray(image)
-    max_value = float(np.max(image))
-    if max_value <= 0:
-        return np.zeros(image.shape, dtype=np.uint8)
-    scaled = np.asarray(image, dtype=np.float32) / max_value * 255
-    return np.ascontiguousarray(np.rint(scaled).astype(np.uint8))
-
-
-def _measurement_type(measurement: Measurement) -> str | None:
-    for measurement_type in sorted(MEASUREMENT_TYPE_ORDER, key=len, reverse=True):
-        if measurement.name.endswith(measurement_type):
-            return measurement_type
-    return None
-
-
-def _target_id(measurement: Measurement, measurement_type: str) -> str:
-    prefix = measurement.name[: -len(measurement_type)].strip()
-    return prefix or "M001"
 
 
 def _format_export_message(

--- a/src/measurer/image_display.py
+++ b/src/measurer/image_display.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def normalize_to_uint8(image: np.ndarray) -> np.ndarray:
+    if image.dtype == np.uint8:
+        return np.ascontiguousarray(image)
+    max_value = float(np.max(image))
+    if max_value <= 0:
+        return np.zeros(image.shape, dtype=np.uint8)
+    scaled = np.asarray(image, dtype=np.float32) / max_value * 255
+    return np.ascontiguousarray(np.rint(scaled).astype(np.uint8))

--- a/src/measurer/image_queue.py
+++ b/src/measurer/image_queue.py
@@ -6,6 +6,16 @@ from pathlib import Path
 import numpy as np
 import tifffile
 
+from measurer.roi import (
+    PolygonRoi,
+    RectRoi,
+    RoiSelection,
+    clamp_polygon_roi_to_image,
+    clamp_rect_roi_to_image,
+    roi_union_area_px,
+    roi_union_mask,
+)
+
 
 @dataclass(frozen=True)
 class ScaleResolution:
@@ -17,81 +27,6 @@ class ScaleResolution:
 class LoadedImage:
     image: np.ndarray
     metadata_nm_per_px: float | None = None
-
-
-@dataclass(frozen=True)
-class RectRoi:
-    x: int
-    y: int
-    width: int
-    height: int
-
-
-@dataclass(frozen=True)
-class PolygonRoi:
-    points: tuple[tuple[int, int], ...]
-
-
-@dataclass(frozen=True)
-class RoiSelection:
-    rectangles: tuple[RectRoi, ...] = ()
-    polygons: tuple[PolygonRoi, ...] = ()
-    shape_order: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        if self.shape_order:
-            return
-        object.__setattr__(
-            self,
-            "shape_order",
-            ("rectangle",) * len(self.rectangles)
-            + ("polygon",) * len(self.polygons),
-        )
-
-    @property
-    def is_empty(self) -> bool:
-        return len(self.rectangles) == 0 and len(self.polygons) == 0
-
-    @property
-    def bounding_box(self) -> RectRoi | None:
-        if self.is_empty:
-            return None
-
-        boxes = [rect for rect in self.rectangles]
-        boxes.extend(
-            box
-            for polygon in self.polygons
-            if (box := _polygon_bounding_box(polygon)) is not None
-        )
-        if not boxes:
-            return None
-
-        left = min(rect.x for rect in boxes)
-        top = min(rect.y for rect in boxes)
-        right = max(rect.x + rect.width for rect in boxes)
-        bottom = max(rect.y + rect.height for rect in boxes)
-        return RectRoi(x=left, y=top, width=right - left, height=bottom - top)
-
-    def bounding_box_for_image(self, image: np.ndarray) -> RectRoi | None:
-        boxes = [
-            clamped
-            for rectangle in self.rectangles
-            if (clamped := _clamp_roi_to_image(rectangle, image)) is not None
-        ]
-        boxes.extend(
-            box
-            for polygon in self.polygons
-            if (clamped := _clamp_polygon_to_image(polygon, image)) is not None
-            if (box := _polygon_bounding_box(clamped)) is not None
-        )
-        if not boxes:
-            return None
-
-        left = min(rect.x for rect in boxes)
-        top = min(rect.y for rect in boxes)
-        right = max(rect.x + rect.width for rect in boxes)
-        bottom = max(rect.y + rect.height for rect in boxes)
-        return RectRoi(x=left, y=top, width=right - left, height=bottom - top)
 
 
 @dataclass(frozen=True)
@@ -299,7 +234,7 @@ class ImageQueue:
             return False
 
         row = self.rows[row_index]
-        clamped_roi = _clamp_roi_to_image(roi, row.image)
+        clamped_roi = clamp_rect_roi_to_image(roi, row.image)
         if clamped_roi is None:
             return False
 
@@ -324,7 +259,7 @@ class ImageQueue:
             return False
 
         row = self.rows[row_index]
-        clamped_roi = _clamp_polygon_to_image(roi, row.image)
+        clamped_roi = clamp_polygon_roi_to_image(roi, row.image)
         if clamped_roi is None:
             return False
 
@@ -500,116 +435,3 @@ def _to_grayscale(image: np.ndarray) -> np.ndarray:
 
 def _count_skip(skipped_reasons: dict[str, int], reason: str) -> None:
     skipped_reasons[reason] = skipped_reasons.get(reason, 0) + 1
-
-
-def _clamp_roi_to_image(roi: RectRoi, image: np.ndarray) -> RectRoi | None:
-    image_height, image_width = image.shape
-    left = max(0, roi.x)
-    top = max(0, roi.y)
-    right = min(image_width, roi.x + roi.width)
-    bottom = min(image_height, roi.y + roi.height)
-    width = right - left
-    height = bottom - top
-    if width <= 0 or height <= 0:
-        return None
-    return RectRoi(x=left, y=top, width=width, height=height)
-
-
-def _clamp_polygon_to_image(roi: PolygonRoi, image: np.ndarray) -> PolygonRoi | None:
-    image_height, image_width = image.shape
-    clamped_points = tuple(
-        (
-            min(max(0, int(x)), image_width - 1),
-            min(max(0, int(y)), image_height - 1),
-        )
-        for x, y in roi.points
-    )
-    if len(set(clamped_points)) < 3:
-        return None
-
-    box = _polygon_bounding_box(PolygonRoi(clamped_points))
-    if box is None or box.width <= 1 or box.height <= 1:
-        return None
-    return PolygonRoi(clamped_points)
-
-
-def _polygon_bounding_box(roi: PolygonRoi) -> RectRoi | None:
-    if len(roi.points) < 3:
-        return None
-
-    xs = [point[0] for point in roi.points]
-    ys = [point[1] for point in roi.points]
-    left = min(xs)
-    top = min(ys)
-    right = max(xs)
-    bottom = max(ys)
-    return RectRoi(x=left, y=top, width=right - left + 1, height=bottom - top + 1)
-
-
-def roi_union_mask(
-    roi: RoiSelection, image: np.ndarray, analysis_region: RectRoi
-) -> np.ndarray:
-    if roi.is_empty:
-        return np.ones((analysis_region.height, analysis_region.width), dtype=bool)
-
-    mask = np.zeros((analysis_region.height, analysis_region.width), dtype=bool)
-    for rectangle in roi.rectangles:
-        clamped = _clamp_roi_to_image(rectangle, image)
-        if clamped is None:
-            continue
-        left = max(0, clamped.x - analysis_region.x)
-        top = max(0, clamped.y - analysis_region.y)
-        right = min(mask.shape[1], left + clamped.width)
-        bottom = min(mask.shape[0], top + clamped.height)
-        mask[top:bottom, left:right] = True
-
-    for polygon in roi.polygons:
-        clamped = _clamp_polygon_to_image(polygon, image)
-        if clamped is None:
-            continue
-        mask |= _polygon_mask(clamped, analysis_region)
-
-    return mask
-
-
-def _polygon_mask(roi: PolygonRoi, analysis_region: RectRoi) -> np.ndarray:
-    height = analysis_region.height
-    width = analysis_region.width
-    mask = np.zeros((height, width), dtype=bool)
-    points = roi.points
-    for local_y in range(height):
-        y = analysis_region.y + local_y + 0.5
-        for local_x in range(width):
-            x = analysis_region.x + local_x + 0.5
-            if _point_in_polygon(x, y, points):
-                mask[local_y, local_x] = True
-    return mask
-
-
-def _point_in_polygon(
-    x: float, y: float, points: tuple[tuple[int, int], ...]
-) -> bool:
-    inside = False
-    previous_x, previous_y = points[-1]
-    for current_x, current_y in points:
-        crosses_y = (current_y > y) != (previous_y > y)
-        if crosses_y:
-            edge_x = (previous_x - current_x) * (y - current_y) / (
-                previous_y - current_y
-            ) + current_x
-            if x < edge_x:
-                inside = not inside
-        previous_x, previous_y = current_x, current_y
-    return inside
-
-
-def roi_union_area_px(roi: RoiSelection, image: np.ndarray) -> int:
-    if roi.is_empty:
-        return image.size
-
-    analysis_region = roi.bounding_box_for_image(image)
-    if analysis_region is None:
-        return 0
-
-    mask = roi_union_mask(roi, image, analysis_region)
-    return int(np.count_nonzero(mask))

--- a/src/measurer/measurement.py
+++ b/src/measurer/measurement.py
@@ -5,7 +5,12 @@ from math import ceil
 
 import numpy as np
 
-from measurer.image_queue import RectRoi, RoiSelection, roi_union_mask
+from measurer.roi import (
+    RectRoi,
+    RoiSelection,
+    clamp_rect_roi_to_image,
+    roi_union_mask,
+)
 
 HARD_MIN_COMPONENT_AREA_PX = 100
 MIN_AREA_RATIO_TO_MEDIAN = 0.03
@@ -184,12 +189,12 @@ def _analysis_region_for(
         if bounding_box is None:
             return RectRoi(x=0, y=0, width=image_width, height=image_height)
 
-        clamped_roi = _clamped_roi(bounding_box, image)
+        clamped_roi = clamp_rect_roi_to_image(bounding_box, image)
         if clamped_roi is None:
             return RectRoi(x=0, y=0, width=image_width, height=image_height)
         return clamped_roi
 
-    clamped_roi = _clamped_roi(roi, image)
+    clamped_roi = clamp_rect_roi_to_image(roi, image)
     if clamped_roi is None:
         return RectRoi(x=0, y=0, width=0, height=0)
     return clamped_roi
@@ -207,19 +212,6 @@ def _analysis_mask_for(
         return mask
 
     return roi_union_mask(roi, image, analysis_region)
-
-
-def _clamped_roi(roi: RectRoi, image: np.ndarray) -> RectRoi | None:
-    image_height, image_width = image.shape
-    left = max(0, roi.x)
-    top = max(0, roi.y)
-    right = min(image_width, roi.x + roi.width)
-    bottom = min(image_height, roi.y + roi.height)
-    width = right - left
-    height = bottom - top
-    if width <= 0 or height <= 0:
-        return None
-    return RectRoi(x=left, y=top, width=width, height=height)
 
 
 def _otsu_threshold(region: np.ndarray) -> float:

--- a/src/measurer/measurement_report.py
+++ b/src/measurer/measurement_report.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from measurer.measurement import Measurement, MeasurementResult
+
+
+MEASUREMENT_TYPE_ORDER = (
+    "TCD",
+    "BCD",
+    "Height",
+    "Horizontal Space",
+    "Vertical Space",
+)
+
+MEASUREMENT_TYPE_COLORS = {
+    "TCD": (64, 196, 255),
+    "BCD": (255, 183, 77),
+    "Height": (255, 210, 64),
+    "Horizontal Space": (186, 104, 200),
+    "Vertical Space": (129, 199, 132),
+}
+
+
+@dataclass(frozen=True)
+class MeasurementReportKey:
+    measurement_type: str
+    target_id: str
+
+
+@dataclass(frozen=True)
+class MeasurementReportItem:
+    measurement: Measurement
+    measurement_type: str
+    target_id: str
+    display_value: float
+    unit: str
+    label: str
+    color_rgb: tuple[int, int, int]
+
+
+def successful_measurement_report_items(
+    result: MeasurementResult, nm_per_px: float | None
+) -> list[MeasurementReportItem]:
+    unit = "px" if nm_per_px is None else "nm"
+    scale = 1.0 if nm_per_px is None else nm_per_px
+    items: list[MeasurementReportItem] = []
+    for measurement in result.measurements.values():
+        if measurement.status != "success":
+            continue
+        report_key = measurement_report_key(measurement)
+        if report_key is None:
+            continue
+        display_value = measurement.value_px * scale
+        items.append(
+            MeasurementReportItem(
+                measurement=measurement,
+                measurement_type=report_key.measurement_type,
+                target_id=report_key.target_id,
+                display_value=display_value,
+                unit=unit,
+                label=f"{display_value:.1f} {unit}",
+                color_rgb=MEASUREMENT_TYPE_COLORS[report_key.measurement_type],
+            )
+        )
+    return items
+
+
+def format_measurement_summary(
+    result: MeasurementResult, nm_per_px: float | None
+) -> str:
+    values_by_type: dict[str, list[float]] = {
+        measurement_type: [] for measurement_type in MEASUREMENT_TYPE_ORDER
+    }
+    for item in successful_measurement_report_items(result, nm_per_px):
+        values_by_type[item.measurement_type].append(item.display_value)
+
+    parts = []
+    unit = "px" if nm_per_px is None else "nm"
+    for measurement_type in MEASUREMENT_TYPE_ORDER:
+        values = values_by_type[measurement_type]
+        if not values:
+            continue
+        minimum = min(values)
+        maximum = max(values)
+        value_label = (
+            f"{minimum:.1f}"
+            if minimum == maximum
+            else f"{minimum:.1f}-{maximum:.1f}"
+        )
+        parts.append(f"{measurement_type}: {value_label} {unit} (n={len(values)})")
+    return " | ".join(parts)
+
+
+def measurement_report_key(measurement: Measurement) -> MeasurementReportKey | None:
+    measurement_type = measurement_type_from_name(measurement.name)
+    if measurement_type is None:
+        return None
+
+    return MeasurementReportKey(
+        measurement_type=measurement_type,
+        target_id=target_id_from_name(measurement.name, measurement_type),
+    )
+
+
+def measurement_type_from_name(name: str) -> str | None:
+    for measurement_type in sorted(MEASUREMENT_TYPE_ORDER, key=len, reverse=True):
+        if name.endswith(measurement_type):
+            return measurement_type
+    return None
+
+
+def target_id_from_name(name: str, measurement_type: str) -> str:
+    prefix = name[: -len(measurement_type)].strip()
+    return prefix or "M001"

--- a/src/measurer/roi.py
+++ b/src/measurer/roi.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class RectRoi:
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class PolygonRoi:
+    points: tuple[tuple[int, int], ...]
+
+
+@dataclass(frozen=True)
+class RoiSelection:
+    rectangles: tuple[RectRoi, ...] = ()
+    polygons: tuple[PolygonRoi, ...] = ()
+    shape_order: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.shape_order:
+            return
+        object.__setattr__(
+            self,
+            "shape_order",
+            ("rectangle",) * len(self.rectangles)
+            + ("polygon",) * len(self.polygons),
+        )
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self.rectangles) == 0 and len(self.polygons) == 0
+
+    @property
+    def bounding_box(self) -> RectRoi | None:
+        if self.is_empty:
+            return None
+
+        boxes = [rect for rect in self.rectangles]
+        boxes.extend(
+            box
+            for polygon in self.polygons
+            if (box := polygon_bounding_box(polygon)) is not None
+        )
+        if not boxes:
+            return None
+
+        left = min(rect.x for rect in boxes)
+        top = min(rect.y for rect in boxes)
+        right = max(rect.x + rect.width for rect in boxes)
+        bottom = max(rect.y + rect.height for rect in boxes)
+        return RectRoi(x=left, y=top, width=right - left, height=bottom - top)
+
+    def bounding_box_for_image(self, image: np.ndarray) -> RectRoi | None:
+        boxes = [
+            clamped
+            for rectangle in self.rectangles
+            if (clamped := clamp_rect_roi_to_image(rectangle, image)) is not None
+        ]
+        boxes.extend(
+            box
+            for polygon in self.polygons
+            if (clamped := clamp_polygon_roi_to_image(polygon, image)) is not None
+            if (box := polygon_bounding_box(clamped)) is not None
+        )
+        if not boxes:
+            return None
+
+        left = min(rect.x for rect in boxes)
+        top = min(rect.y for rect in boxes)
+        right = max(rect.x + rect.width for rect in boxes)
+        bottom = max(rect.y + rect.height for rect in boxes)
+        return RectRoi(x=left, y=top, width=right - left, height=bottom - top)
+
+
+def clamp_rect_roi_to_image(roi: RectRoi, image: np.ndarray) -> RectRoi | None:
+    image_height, image_width = image.shape
+    left = max(0, roi.x)
+    top = max(0, roi.y)
+    right = min(image_width, roi.x + roi.width)
+    bottom = min(image_height, roi.y + roi.height)
+    width = right - left
+    height = bottom - top
+    if width <= 0 or height <= 0:
+        return None
+    return RectRoi(x=left, y=top, width=width, height=height)
+
+
+def clamp_polygon_roi_to_image(
+    roi: PolygonRoi, image: np.ndarray
+) -> PolygonRoi | None:
+    image_height, image_width = image.shape
+    clamped_points = tuple(
+        (
+            min(max(0, int(x)), image_width - 1),
+            min(max(0, int(y)), image_height - 1),
+        )
+        for x, y in roi.points
+    )
+    if len(set(clamped_points)) < 3:
+        return None
+
+    box = polygon_bounding_box(PolygonRoi(clamped_points))
+    if box is None or box.width <= 1 or box.height <= 1:
+        return None
+    return PolygonRoi(clamped_points)
+
+
+def polygon_bounding_box(roi: PolygonRoi) -> RectRoi | None:
+    if len(roi.points) < 3:
+        return None
+
+    xs = [point[0] for point in roi.points]
+    ys = [point[1] for point in roi.points]
+    left = min(xs)
+    top = min(ys)
+    right = max(xs)
+    bottom = max(ys)
+    return RectRoi(x=left, y=top, width=right - left + 1, height=bottom - top + 1)
+
+
+def roi_union_mask(
+    roi: RoiSelection, image: np.ndarray, analysis_region: RectRoi
+) -> np.ndarray:
+    if roi.is_empty:
+        return np.ones((analysis_region.height, analysis_region.width), dtype=bool)
+
+    mask = np.zeros((analysis_region.height, analysis_region.width), dtype=bool)
+    for rectangle in roi.rectangles:
+        clamped = clamp_rect_roi_to_image(rectangle, image)
+        if clamped is None:
+            continue
+        left = max(0, clamped.x - analysis_region.x)
+        top = max(0, clamped.y - analysis_region.y)
+        right = min(mask.shape[1], left + clamped.width)
+        bottom = min(mask.shape[0], top + clamped.height)
+        mask[top:bottom, left:right] = True
+
+    for polygon in roi.polygons:
+        clamped = clamp_polygon_roi_to_image(polygon, image)
+        if clamped is None:
+            continue
+        mask |= _polygon_mask(clamped, analysis_region)
+
+    return mask
+
+
+def roi_union_area_px(roi: RoiSelection, image: np.ndarray) -> int:
+    if roi.is_empty:
+        return image.size
+
+    analysis_region = roi.bounding_box_for_image(image)
+    if analysis_region is None:
+        return 0
+
+    mask = roi_union_mask(roi, image, analysis_region)
+    return int(np.count_nonzero(mask))
+
+
+def _polygon_mask(roi: PolygonRoi, analysis_region: RectRoi) -> np.ndarray:
+    height = analysis_region.height
+    width = analysis_region.width
+    mask = np.zeros((height, width), dtype=bool)
+    points = roi.points
+    for local_y in range(height):
+        y = analysis_region.y + local_y + 0.5
+        for local_x in range(width):
+            x = analysis_region.x + local_x + 0.5
+            if _point_in_polygon(x, y, points):
+                mask[local_y, local_x] = True
+    return mask
+
+
+def _point_in_polygon(
+    x: float, y: float, points: tuple[tuple[int, int], ...]
+) -> bool:
+    inside = False
+    previous_x, previous_y = points[-1]
+    for current_x, current_y in points:
+        crosses_y = (current_y > y) != (previous_y > y)
+        if crosses_y:
+            edge_x = (previous_x - current_x) * (y - current_y) / (
+                previous_y - current_y
+            ) + current_x
+            if x < edge_x:
+                inside = not inside
+        previous_x, previous_y = current_x, current_y
+    return inside

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
 
 import measurer.app as app_module
 from measurer.app import create_window
+from measurer.box_plot import BoxPlotPoint, box_plot_buckets, box_plot_ticks
 from measurer.synthetic import SingleMetalIslandSpec, create_single_metal_island_image
 
 
@@ -927,13 +928,13 @@ def test_app_box_plot_shows_empty_state_when_all_measurement_types_are_hidden(
 
 def test_box_plot_buckets_alternate_groups_within_each_measurement_type():
     points = [
-        app_module.BoxPlotPoint("LF", "BCD", 4.0, "px"),
-        app_module.BoxPlotPoint("EF", "BCD", 3.0, "px"),
-        app_module.BoxPlotPoint("LF", "TCD", 2.0, "px"),
-        app_module.BoxPlotPoint("EF", "TCD", 1.0, "px"),
+        BoxPlotPoint("LF", "BCD", 4.0, "px"),
+        BoxPlotPoint("EF", "BCD", 3.0, "px"),
+        BoxPlotPoint("LF", "TCD", 2.0, "px"),
+        BoxPlotPoint("EF", "TCD", 1.0, "px"),
     ]
 
-    buckets = app_module._box_plot_buckets(points)
+    buckets = box_plot_buckets(points)
 
     assert [key for key, _values in buckets] == [
         ("EF", "TCD"),
@@ -944,7 +945,7 @@ def test_box_plot_buckets_alternate_groups_within_each_measurement_type():
 
 
 def test_box_plot_ticks_include_range_endpoints():
-    ticks = app_module._box_plot_ticks(26.0, 60.0)
+    ticks = box_plot_ticks(26.0, 60.0)
 
     assert ticks == [26.0, 34.5, 43.0, 51.5, 60.0]
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,8 +2,9 @@ import numpy as np
 from openpyxl import load_workbook
 
 from measurer.export import export_measured_batch
-from measurer.image_queue import ImageQueue, PolygonRoi, RectRoi
+from measurer.image_queue import ImageQueue
 from measurer.measurement import measure_image
+from measurer.roi import PolygonRoi, RectRoi
 from measurer.synthetic import SingleMetalIslandSpec, create_single_metal_island_image
 
 

--- a/tests/test_image_display.py
+++ b/tests/test_image_display.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from measurer.image_display import normalize_to_uint8
+
+
+def test_normalize_to_uint8_keeps_uint8_values_contiguous():
+    image = np.arange(9, dtype=np.uint8).reshape(3, 3)[:, ::-1]
+
+    display = normalize_to_uint8(image)
+
+    assert display.dtype == np.uint8
+    assert display.flags.c_contiguous
+    np.testing.assert_array_equal(display, image)
+
+
+def test_normalize_to_uint8_scales_positive_image_to_display_range():
+    image = np.asarray([[0, 10], [20, 40]], dtype=np.uint16)
+
+    display = normalize_to_uint8(image)
+
+    np.testing.assert_array_equal(
+        display,
+        np.asarray([[0, 64], [128, 255]], dtype=np.uint8),
+    )
+
+
+def test_normalize_to_uint8_handles_all_dark_image():
+    image = np.zeros((2, 3), dtype=np.uint16)
+
+    display = normalize_to_uint8(image)
+
+    np.testing.assert_array_equal(display, np.zeros((2, 3), dtype=np.uint8))

--- a/tests/test_image_queue.py
+++ b/tests/test_image_queue.py
@@ -1,7 +1,8 @@
 import numpy as np
 import tifffile
 
-from measurer.image_queue import ImageQueue, PolygonRoi, RectRoi, ScaleResolution
+from measurer.image_queue import ImageQueue, ScaleResolution
+from measurer.roi import PolygonRoi, RectRoi
 
 
 def test_add_images_accepts_dm3_2d_image_with_px_fallback(monkeypatch, tmp_path):

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
 
-from measurer.image_queue import PolygonRoi, RectRoi, RoiSelection
 from measurer.measurement import (
     MeasurementConfig,
     Point,
     _measure_single_metal_island,
     measure_image,
 )
+from measurer.roi import PolygonRoi, RectRoi, RoiSelection
 from measurer.synthetic import SingleMetalIslandSpec, create_single_metal_island_image
 
 

--- a/tests/test_measurement_report.py
+++ b/tests/test_measurement_report.py
@@ -1,0 +1,107 @@
+from measurer.measurement import (
+    Measurement,
+    MeasurementLine,
+    MeasurementResult,
+    Point,
+    RefinedBoundary,
+)
+from measurer.measurement_report import (
+    MEASUREMENT_TYPE_COLORS,
+    MEASUREMENT_TYPE_ORDER,
+    format_measurement_summary,
+    measurement_report_key,
+    successful_measurement_report_items,
+)
+from measurer.roi import RectRoi
+
+
+def _measurement(name: str) -> Measurement:
+    return Measurement(
+        name=name,
+        value_px=1.0,
+        line=MeasurementLine(start=Point(0, 0), end=Point(1, 0)),
+    )
+
+
+def _result(measurements: dict[str, Measurement]) -> MeasurementResult:
+    return MeasurementResult(
+        status="success",
+        analysis_region=RectRoi(x=0, y=0, width=10, height=10),
+        refined_boundary=RefinedBoundary(points=[]),
+        measurements=measurements,
+    )
+
+
+def test_measurement_report_key_extracts_type_and_target_id():
+    report_key = measurement_report_key(_measurement("M001-M002 Horizontal Space"))
+
+    assert report_key is not None
+    assert report_key.measurement_type == "Horizontal Space"
+    assert report_key.target_id == "M001-M002"
+
+
+def test_measurement_report_key_defaults_single_metal_island_target_id():
+    report_key = measurement_report_key(_measurement("TCD"))
+
+    assert report_key is not None
+    assert report_key.measurement_type == "TCD"
+    assert report_key.target_id == "M001"
+
+
+def test_measurement_report_defines_all_display_colors():
+    assert set(MEASUREMENT_TYPE_COLORS) == set(MEASUREMENT_TYPE_ORDER)
+
+
+def test_successful_measurement_report_items_apply_scale_label_and_color():
+    result = _result(
+        {
+            "TCD": Measurement(
+                name="M002 TCD",
+                value_px=10.0,
+                line=MeasurementLine(start=Point(1, 2), end=Point(11, 2)),
+            ),
+            "failed": Measurement(
+                name="M002 BCD",
+                value_px=float("nan"),
+                line=MeasurementLine(start=Point(1, 8), end=Point(11, 8)),
+                status="failed",
+            ),
+        }
+    )
+
+    items = successful_measurement_report_items(result, nm_per_px=0.5)
+
+    assert len(items) == 1
+    assert items[0].measurement_type == "TCD"
+    assert items[0].target_id == "M002"
+    assert items[0].display_value == 5.0
+    assert items[0].unit == "nm"
+    assert items[0].label == "5.0 nm"
+    assert items[0].color_rgb == MEASUREMENT_TYPE_COLORS["TCD"]
+
+
+def test_format_measurement_summary_groups_values_by_measurement_type():
+    result = _result(
+        {
+            "first": Measurement(
+                name="M001 TCD",
+                value_px=10.0,
+                line=MeasurementLine(start=Point(0, 0), end=Point(10, 0)),
+            ),
+            "second": Measurement(
+                name="M002 TCD",
+                value_px=20.0,
+                line=MeasurementLine(start=Point(0, 1), end=Point(20, 1)),
+            ),
+            "height": Measurement(
+                name="M001 Height",
+                value_px=30.0,
+                line=MeasurementLine(start=Point(5, 0), end=Point(5, 30)),
+            ),
+        }
+    )
+
+    assert (
+        format_measurement_summary(result, nm_per_px=None)
+        == "TCD: 10.0-20.0 px (n=2) | Height: 30.0 px (n=1)"
+    )


### PR DESCRIPTION
## Summary

Refactor measurement and display support code into deeper modules with smaller interfaces:

- Move ROI geometry and ROI Union helpers into `measurer.roi`.
- Move measurement reporting keys, labels, summaries, colors, and successful report items into `measurer.measurement_report`.
- Move Box Plot data aggregation, ordering, summaries, ticks, and percentile math into `measurer.box_plot`.
- Move shared grayscale display normalization into `measurer.image_display`.
- Update GUI, export, and tests to consume the new module interfaces.
- Update README as the project source of truth.

## Why

The previous implementation duplicated presentation and ROI rules across `app.py`, `export.py`, `image_queue.py`, and `measurement.py`. This concentrated too many details in the GUI module and made Result View, Export, Box Plot, and measurement code easier to drift apart.

## Validation

- `uv run pytest` -> 126 passed
- `git diff --check` -> passed