### PR TITLE
[codex] Improve codebase architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ assets/icons/measurer.ico
 - TIFF 若有一致的 X/Y resolution metadata，會換算成 metadata `nm / pixel`。
 - RGB/RGBA TIFF 直接轉 grayscale，不顯示 warning。
 - multi-page TIFF / unsupported `.dm3` shape / 3D stack / unreadable image data 在 Add Images 時 skip，不加入 queue。
+- TIFF / `.dm3` 讀取、grayscale conversion 與 metadata `nm / pixel` parsing 已集中在 `image_input.py`；`image_queue.py` 只負責 File Queue state、Group、scale、ROI 與 Measure / Export status。
 - Add Images batch summary 顯示 added / skipped 與原因數量。
 - duplicate absolute file path 直接忽略，不重設既有 row。
 - file queue 支援一般點選單列；需要多列 Set Group 時可用 Shift / Cmd / Ctrl 這類系統標準多選手勢。File Queue 不允許直接 double-click 編輯欄位，Group 只能透過 Set Group 控制修改。
@@ -41,7 +42,7 @@ assets/icons/measurer.ico
 - incomplete polygon drawing 不會加入 ROI Union，也不會影響 Measure Current。
 - Original / Debug workspace 會顯示既有 ROI；拖選 rectangle 或繪製 polygon 時會顯示 cyan outline，不用實心色塊蓋住影像。
 - Image workspace 會等比例 fit 影像，不讓大型原始影像的 pixmap size 撐壞視窗比例。
-- Original preview、Result Image 與 Debug Image 共用同一套 grayscale display normalization，避免 GUI 預覽與匯出圖片亮度轉換規則分歧。
+- Original preview、Result Image、Debug View 與 Debug Image 共用同一套 grayscale display normalization，避免 GUI 預覽與匯出圖片亮度轉換規則分歧。
 - Undo ROI 會移除最近完成的 ROI Shape，不論是 rectangle 或 polygon；Undo 到沒有 ROI Shapes 時回到 Full image。
 - Clear ROI 會回到 Full image。
 - ROI geometry 會 clamp 在 image bounds 內。
@@ -74,6 +75,7 @@ assets/icons/measurer.ico
 - Result View 下方 summary 依 measurement type 彙整 value range 與 count，避免多 Metal Islands 時把每一筆完整名稱串成難讀長句。
 - Result View 使用固定 measurement type 顏色：TCD cyan、BCD orange、Height yellow、Horizontal Space magenta、Vertical Space lime。
 - Result View、Box Plot preview 與 Export 目前共用同一組 measurement type 順序、target ID 解析、scale label、summary 與顏色定義，避免 GUI 與匯出結果對 TCD / BCD / Height / Horizontal Space / Vertical Space 的呈現規則分歧。
+- Exported Result Image rendering 已集中在 `result_render.py`；之後若要調整 official Measurement Lines 與 value label 的 QImage rendering，優先改這個 module。
 - Result View 數值文字顯示在線段中心附近，使用白字加 dark outline，會 clamp 在 image bounds 內，並用固定上下偏移減少局部碰撞；若仍重疊，不讓 rendering failed。
 - batch manual default 或單張 manual override 改變後，Result View 會用現有 px geometry 重新換算顯示值與單位，不需要重測。
 - Box Plot preview 已可從 GUI 切換，會依 Group 與 measurement type 彙整 successful final measurements，使用 canvas 依目前顯示尺寸繪製 raw points with jitter、左側 y-axis 刻度與 summary/status panel；x-axis 先依 measurement type 分群，再在群內並排各 Group 方便比較。
@@ -82,6 +84,7 @@ assets/icons/measurer.ico
 - Group、batch manual default 或單張 manual override 改變後，Box Plot preview 會重新聚合現有 measurement results，不需要重測。
 - Box Plot preview 不混合 nm 與 px；同時存在 nm 與 px measurement results 時，顯示 warning 而不畫 mixed-unit plot。
 - Debug View 已有最小 diagnostics：rough mask、kept candidates、excluded small components、excluded boundary-touch components、rejected Space pair count、refined points、fallback points、fallback ratio。
+- Debug View / Debug Image 的 rough mask、candidate boxes 與 Refined Boundary diagnostic rendering 已集中在 `debug_render.py`，避免 GUI 與匯出圖各自維護一套 diagnostic drawing rules。
 - Export button 已支援 single-source / multi-source folder MVS：只輸出 Measured 圖片，Pending / Failed 不輸出圖片也不寫入 Excel。
 - 如果沒有 Measured 圖片，Export 會被阻止，不建立 output folders/files，status card 顯示 `No measured images to export.`。
 - single-source Export 會在原圖資料夾下建立 `measured_image/` 與 `debug_image/`。
@@ -93,6 +96,7 @@ assets/icons/measurer.ico
 - Excel Summary 依 Group、measurement type、unit 彙整 successful measurements，不混合 nm 與 px。
 - Excel Measurements / Trace 只包含 Measured 圖片內產生的 final measurements，並使用 export 當下的 scale state。
 - Excel Trace Sheet 記錄 ROI metadata：Full image 使用 `roi_type = full_image` 與 `roi_shape_count = 0`；一個或多個 ROI Shapes 使用 `roi_type = union`、ROI Union bounding box、以及 completed ROI Shape 數量。
+- Trace Sheet header、ROI Union metadata、scale source 與 Refined Boundary refined/fallback summary 已集中在 `trace_sheet.py`；`export.py` 只負責 workbook / file output orchestration。
 - file queue row 預設顯示：
   - Group = `Default`
   - ROI = `Full image`
@@ -1099,6 +1103,8 @@ Debug View 是工程師排錯用，不是報告用。
 - 下方文字顯示 kept / excluded 類別數量，以及 refined point count / fallback point count / fallback ratio。
 
 Debug Image export 已有 MVS 2x2 panel。完整 export-grade diagnostics 尚未實作。
+
+Debug View / Debug Image 的 diagnostic drawing rules 由 `debug_render.py` 共用；exported Result Image 的 official Measurement Lines rendering 由 `result_render.py` 共用。這樣做的原因是 GUI diagnostic display 與 Export artifact 需要一致；取捨是 PySide6 QImage rendering 相關邏輯會集中在這兩個 module，而不是全部留在 `app.py` 或 `export.py`。
 
 MVS Debug Image 使用 2x2 panel：
 

--- a/src/measurer/app.py
+++ b/src/measurer/app.py
@@ -37,6 +37,7 @@ from measurer.box_plot import (
     format_box_plot_summary,
     percentile,
 )
+from measurer.debug_render import debug_view_qimage
 from measurer.export import OverwriteSummary, export_measured_batch
 from measurer.image_display import normalize_to_uint8
 from measurer.image_queue import (
@@ -952,7 +953,9 @@ class MeasurerWindow(QMainWindow):
             self._sync_view_buttons()
             return
 
-        self.image_label.setPixmap(_debug_to_pixmap(row.image, row.measurement_debug))
+        self.image_label.setPixmap(
+            QPixmap.fromImage(debug_view_qimage(row.image, row.measurement_debug))
+        )
         self.image_label.set_measurement_overlay(None, None)
         self.image_label.set_roi(row.roi, visible=True)
         self.result_values_label.setText(_format_debug_values(row.measurement_debug))
@@ -1159,87 +1162,6 @@ def _draw_outlined_text(painter: QPainter, label_rect: QRect, text: str) -> None
         painter.drawText(baseline_x + dx, baseline_y + dy, text)
     painter.setPen(QPen(QColor(245, 248, 252), 1))
     painter.drawText(baseline_x, baseline_y, text)
-
-
-def _debug_to_pixmap(image: np.ndarray, result: MeasurementResult) -> QPixmap:
-    display = normalize_to_uint8(image)
-    height, width = display.shape
-    rgb = np.ascontiguousarray(np.dstack([display, display, display]))
-    if result.detection is not None:
-        region = result.analysis_region
-        rough_mask = result.detection.rough_mask
-        region_rgb = rgb[
-            region.y : region.y + region.height,
-            region.x : region.x + region.width,
-        ]
-        region_rgb[rough_mask] = (
-            region_rgb[rough_mask].astype(np.uint16) // 2
-            + np.asarray([24, 96, 180], dtype=np.uint16)
-        ).astype(np.uint8)
-
-    qimage = QImage(
-        rgb.data,
-        width,
-        height,
-        width * 3,
-        QImage.Format.Format_RGB888,
-    ).copy()
-    painter = QPainter(qimage)
-    if result.detection is not None:
-        _draw_component_boxes(
-            painter,
-            result.analysis_region,
-            result.detection.kept_candidates,
-            QColor(80, 220, 120),
-        )
-        _draw_component_boxes(
-            painter,
-            result.analysis_region,
-            result.detection.excluded_small_components,
-            QColor(255, 190, 64),
-        )
-        _draw_component_boxes(
-            painter,
-            result.analysis_region,
-            result.detection.excluded_boundary_touch_components,
-            QColor(255, 80, 80),
-        )
-    _draw_boundary_points(painter, result)
-    painter.end()
-    return QPixmap.fromImage(qimage)
-
-
-def _draw_boundary_points(painter: QPainter, result: MeasurementResult) -> None:
-    boundaries = (
-        [metal.refined_boundary for metal in result.metal_islands]
-        if result.metal_islands
-        else [result.refined_boundary]
-    )
-    for boundary in boundaries:
-        for point, status in zip(
-            boundary.points,
-            boundary.point_statuses,
-            strict=False,
-        ):
-            if status == "fallback_rough":
-                painter.setPen(QPen(QColor(255, 96, 220), 2))
-            else:
-                painter.setPen(QPen(QColor(120, 240, 255), 2))
-            painter.drawEllipse(point.x - 1, point.y - 1, 3, 3)
-
-
-def _draw_component_boxes(
-    painter, analysis_region: RectRoi, components, color: QColor
-) -> None:
-    painter.setPen(QPen(color, 2))
-    for component in components:
-        min_x, min_y, max_x, max_y = component.bbox
-        painter.drawRect(
-            analysis_region.x + min_x,
-            analysis_region.y + min_y,
-            max_x - min_x + 1,
-            max_y - min_y + 1,
-        )
 
 
 def _format_result_values(

--- a/src/measurer/debug_render.py
+++ b/src/measurer/debug_render.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import numpy as np
+from PySide6.QtGui import QColor, QImage, QPainter, QPen
+
+from measurer.image_display import normalize_to_uint8
+from measurer.measurement import MeasurementResult
+from measurer.result_render import (
+    grayscale_rgb_qimage,
+    result_qimage,
+)
+from measurer.roi import RectRoi
+
+
+def debug_view_qimage(image: np.ndarray, result: MeasurementResult) -> QImage:
+    qimage = rough_mask_qimage(image, result, blend=True)
+    painter = QPainter(qimage)
+    draw_candidate_boxes(painter, result)
+    draw_boundary_points(painter, result)
+    painter.end()
+    return qimage
+
+
+def debug_panel_qimage(image: np.ndarray, result: MeasurementResult) -> QImage:
+    original = grayscale_rgb_qimage(image)
+    width = original.width()
+    height = original.height()
+    debug_image = QImage(width * 2, height * 2, QImage.Format.Format_RGB888)
+    debug_image.fill(QColor(18, 22, 28))
+
+    painter = QPainter(debug_image)
+    painter.drawImage(0, 0, original)
+    painter.drawImage(width, 0, rough_mask_qimage(image, result))
+    painter.drawImage(0, height, candidate_boxes_qimage(image, result))
+    painter.drawImage(width, height, result_qimage(image, result, nm_per_px=None))
+    painter.end()
+    return debug_image
+
+
+def rough_mask_qimage(
+    image: np.ndarray,
+    result: MeasurementResult,
+    *,
+    blend: bool = False,
+) -> QImage:
+    if not blend:
+        qimage = grayscale_rgb_qimage(image)
+        if result.detection is None:
+            return qimage
+
+        painter = QPainter(qimage)
+        painter.setPen(QPen(QColor(24, 96, 180), 1))
+        region = result.analysis_region
+        ys, xs = np.where(result.detection.rough_mask)
+        for x, y in zip(xs, ys, strict=False):
+            painter.drawPoint(region.x + int(x), region.y + int(y))
+        painter.end()
+        return qimage
+
+    if result.detection is None:
+        return grayscale_rgb_qimage(image)
+
+    display = normalize_to_uint8(image)
+    height, width = display.shape
+    rgb = np.ascontiguousarray(np.dstack([display, display, display]))
+    region = result.analysis_region
+    region_rgb = rgb[
+        region.y : region.y + region.height,
+        region.x : region.x + region.width,
+    ]
+    rough_mask = result.detection.rough_mask
+    region_rgb[rough_mask] = (
+        region_rgb[rough_mask].astype(np.uint16) // 2
+        + np.asarray([24, 96, 180], dtype=np.uint16)
+    ).astype(np.uint8)
+    return QImage(
+        rgb.data,
+        width,
+        height,
+        width * 3,
+        QImage.Format.Format_RGB888,
+    ).copy()
+
+
+def candidate_boxes_qimage(image: np.ndarray, result: MeasurementResult) -> QImage:
+    qimage = grayscale_rgb_qimage(image)
+    painter = QPainter(qimage)
+    draw_candidate_boxes(painter, result)
+    painter.end()
+    return qimage
+
+
+def draw_candidate_boxes(painter: QPainter, result: MeasurementResult) -> None:
+    if result.detection is None:
+        return
+
+    for candidates, color in [
+        (result.detection.kept_candidates, QColor(80, 220, 120)),
+        (result.detection.excluded_small_components, QColor(255, 190, 64)),
+        (result.detection.excluded_boundary_touch_components, QColor(255, 80, 80)),
+    ]:
+        _draw_component_boxes(painter, result.analysis_region, candidates, color)
+
+
+def draw_boundary_points(painter: QPainter, result: MeasurementResult) -> None:
+    boundaries = (
+        [metal.refined_boundary for metal in result.metal_islands]
+        if result.metal_islands
+        else [result.refined_boundary]
+    )
+    for boundary in boundaries:
+        for point, status in zip(
+            boundary.points,
+            boundary.point_statuses,
+            strict=False,
+        ):
+            if status == "fallback_rough":
+                painter.setPen(QPen(QColor(255, 96, 220), 2))
+            else:
+                painter.setPen(QPen(QColor(120, 240, 255), 2))
+            painter.drawEllipse(point.x - 1, point.y - 1, 3, 3)
+
+
+def _draw_component_boxes(
+    painter: QPainter,
+    analysis_region: RectRoi,
+    candidates,
+    color: QColor,
+) -> None:
+    painter.setPen(QPen(color, 2))
+    for candidate in candidates:
+        min_x, min_y, max_x, max_y = candidate.bbox
+        painter.drawRect(
+            analysis_region.x + min_x,
+            analysis_region.y + min_y,
+            max_x - min_x + 1,
+            max_y - min_y + 1,
+        )

--- a/src/measurer/export.py
+++ b/src/measurer/export.py
@@ -6,24 +6,24 @@ from statistics import mean, median, pstdev
 
 import numpy as np
 from openpyxl import Workbook
-from PySide6.QtGui import QColor, QImage, QPainter, QPen
 from PySide6.QtWidgets import QApplication
 
-from measurer.image_display import normalize_to_uint8
+from measurer.debug_render import debug_panel_qimage
 from measurer.image_queue import ImageQueue
-from measurer.measurement import Measurement, MeasurementResult
+from measurer.measurement import MeasurementResult
 from measurer.measurement_report import (
     MEASUREMENT_TYPE_ORDER,
     measurement_report_key,
-    successful_measurement_report_items,
 )
-from measurer.roi import RoiSelection
+from measurer.result_render import result_qimage
+from measurer.trace_sheet import TRACE_SHEET_HEADER, trace_sheet_row
 
 
 NO_MEASURED_IMAGES_MESSAGE = "No measured images to export."
 MULTI_SOURCE_OUTPUT_FOLDER_MESSAGE = "Choose an output folder for multi-source export."
 OVERWRITE_CONFIRMATION_MESSAGE = "Confirm overwrite to export."
 _QAPPLICATION: QApplication | None = None
+
 
 @dataclass(frozen=True)
 class OverwriteSummary:
@@ -166,33 +166,14 @@ def _save_result_image(
     output_path: Path,
 ) -> None:
     _ensure_qapplication()
-    qimage = _rgb_qimage(image)
-    painter = QPainter(qimage)
-    _draw_measurement_lines(painter, result, nm_per_px)
-    painter.end()
-    qimage.save(str(output_path))
+    result_qimage(image, result, nm_per_px).save(str(output_path))
 
 
 def _save_debug_image(
     image: np.ndarray, result: MeasurementResult, output_path: Path
 ) -> None:
     _ensure_qapplication()
-    original = _rgb_qimage(image)
-    width = original.width()
-    height = original.height()
-    debug_image = QImage(width * 2, height * 2, QImage.Format.Format_RGB888)
-    debug_image.fill(QColor(18, 22, 28))
-    painter = QPainter(debug_image)
-    painter.drawImage(0, 0, original)
-    painter.drawImage(width, 0, _rough_mask_qimage(image, result))
-    painter.drawImage(0, height, _component_qimage(image, result))
-    result_panel = _rgb_qimage(image)
-    result_painter = QPainter(result_panel)
-    _draw_measurement_lines(result_painter, result, nm_per_px=None)
-    result_painter.end()
-    painter.drawImage(width, height, result_panel)
-    painter.end()
-    debug_image.save(str(output_path))
+    debug_panel_qimage(image, result).save(str(output_path))
 
 
 def _write_workbook(queue: ImageQueue, output_path: Path) -> None:
@@ -218,32 +199,7 @@ def _write_workbook(queue: ImageQueue, output_path: Path) -> None:
     measurements_sheet.append(
         ["file", "group", "measurement type", "target ID", "status", "value", "unit"]
     )
-    trace_sheet.append(
-        [
-            "file",
-            "group",
-            "measurement type",
-            "target ID",
-            "status",
-            "reason",
-            "value_px",
-            "x1_px",
-            "y1_px",
-            "x2_px",
-            "y2_px",
-            "scale_nm_per_px",
-            "scale_source",
-            "roi_type",
-            "roi_x_px",
-            "roi_y_px",
-            "roi_width_px",
-            "roi_height_px",
-            "roi_shape_count",
-            "refined_point_count",
-            "fallback_point_count",
-            "fallback_ratio",
-        ]
-    )
+    trace_sheet.append(TRACE_SHEET_HEADER)
 
     summary_values: dict[tuple[str, str, str], list[float]] = {}
     for row_index, row in enumerate(queue.rows):
@@ -283,7 +239,7 @@ def _write_workbook(queue: ImageQueue, output_path: Path) -> None:
                     value
                 )
             trace_sheet.append(
-                _trace_row(
+                trace_sheet_row(
                     file_name=row.file_name,
                     group=row.group,
                     measurement=measurement,
@@ -292,8 +248,7 @@ def _write_workbook(queue: ImageQueue, output_path: Path) -> None:
                     result=result,
                     scale_source=scale_resolution.source,
                     scale_nm_per_px=scale_resolution.nm_per_px,
-                    roi_type=_roi_type(row.roi),
-                    roi_shape_count=_roi_shape_count(row.roi),
+                    roi=row.roi,
                 )
             )
 
@@ -319,160 +274,6 @@ def _write_workbook(queue: ImageQueue, output_path: Path) -> None:
             ]
         )
     workbook.save(output_path)
-
-
-def _trace_row(
-    file_name: str,
-    group: str,
-    measurement: Measurement,
-    measurement_type: str,
-    target_id: str,
-    result: MeasurementResult,
-    scale_source: str,
-    scale_nm_per_px: float | None,
-    roi_type: str,
-    roi_shape_count: int,
-) -> list[object]:
-    roi = result.analysis_region
-    refined_count, fallback_count, fallback_ratio = _refinement_summary(
-        result, target_id
-    )
-    return [
-        file_name,
-        group,
-        measurement_type,
-        target_id,
-        measurement.status,
-        measurement.failure_reason,
-        measurement.value_px if measurement.status == "success" else None,
-        measurement.line.start.x,
-        measurement.line.start.y,
-        measurement.line.end.x,
-        measurement.line.end.y,
-        scale_nm_per_px,
-        scale_source,
-        roi_type,
-        roi.x,
-        roi.y,
-        roi.width,
-        roi.height,
-        roi_shape_count,
-        refined_count,
-        fallback_count,
-        fallback_ratio,
-    ]
-
-
-def _roi_type(roi: RoiSelection) -> str:
-    if roi.is_empty:
-        return "full_image"
-    return "union"
-
-
-def _roi_shape_count(roi: RoiSelection) -> int:
-    return len(roi.rectangles) + len(roi.polygons)
-
-
-def _refinement_summary(
-    result: MeasurementResult, target_id: str
-) -> tuple[int, int, float | None]:
-    if not result.metal_islands:
-        refined = result.refined_boundary.refined_point_count
-        fallback = result.refined_boundary.fallback_point_count
-        return refined, fallback, _fallback_ratio(refined, fallback)
-
-    target_ids = target_id.split("-")
-    boundaries = [
-        metal.refined_boundary
-        for metal in result.metal_islands
-        if metal.id in target_ids
-    ]
-    if not boundaries and result.metal_islands:
-        boundaries = [result.metal_islands[0].refined_boundary]
-
-    refined = sum(boundary.refined_point_count for boundary in boundaries)
-    fallback = sum(boundary.fallback_point_count for boundary in boundaries)
-    return refined, fallback, _fallback_ratio(refined, fallback)
-
-
-def _fallback_ratio(refined_count: int, fallback_count: int) -> float | None:
-    total = refined_count + fallback_count
-    if total == 0:
-        return None
-    return fallback_count / total
-
-
-def _draw_measurement_lines(
-    painter: QPainter, result: MeasurementResult, nm_per_px: float | None
-) -> None:
-    for item in successful_measurement_report_items(result, nm_per_px):
-        measurement = item.measurement
-        painter.setPen(QPen(QColor(*item.color_rgb), 2))
-        painter.drawLine(
-            measurement.line.start.x,
-            measurement.line.start.y,
-            measurement.line.end.x,
-            measurement.line.end.y,
-        )
-        painter.setPen(QPen(QColor(245, 248, 252), 1))
-        painter.drawText(
-            round((measurement.line.start.x + measurement.line.end.x) / 2),
-            round((measurement.line.start.y + measurement.line.end.y) / 2),
-            item.label,
-        )
-
-
-def _rough_mask_qimage(image: np.ndarray, result: MeasurementResult) -> QImage:
-    qimage = _rgb_qimage(image)
-    if result.detection is None:
-        return qimage
-
-    region = result.analysis_region
-    painter = QPainter(qimage)
-    painter.setPen(QPen(QColor(24, 96, 180), 1))
-    mask = result.detection.rough_mask
-    ys, xs = np.where(mask)
-    for x, y in zip(xs, ys, strict=False):
-        painter.drawPoint(region.x + int(x), region.y + int(y))
-    painter.end()
-    return qimage
-
-
-def _component_qimage(image: np.ndarray, result: MeasurementResult) -> QImage:
-    qimage = _rgb_qimage(image)
-    if result.detection is None:
-        return qimage
-
-    painter = QPainter(qimage)
-    for components, color in [
-        (result.detection.kept_candidates, QColor(80, 220, 120)),
-        (result.detection.excluded_small_components, QColor(255, 190, 64)),
-        (result.detection.excluded_boundary_touch_components, QColor(255, 80, 80)),
-    ]:
-        painter.setPen(QPen(color, 2))
-        for component in components:
-            min_x, min_y, max_x, max_y = component.bbox
-            painter.drawRect(
-                result.analysis_region.x + min_x,
-                result.analysis_region.y + min_y,
-                max_x - min_x + 1,
-                max_y - min_y + 1,
-            )
-    painter.end()
-    return qimage
-
-
-def _rgb_qimage(image: np.ndarray) -> QImage:
-    display = normalize_to_uint8(image)
-    height, width = display.shape
-    rgb = np.ascontiguousarray(np.dstack([display, display, display]))
-    return QImage(
-        rgb.data,
-        width,
-        height,
-        width * 3,
-        QImage.Format.Format_RGB888,
-    ).copy()
 
 
 def _format_export_message(

--- a/src/measurer/image_input.py
+++ b/src/measurer/image_input.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import tifffile
+
+
+@dataclass(frozen=True)
+class LoadedImage:
+    image: np.ndarray
+    metadata_nm_per_px: float | None = None
+
+
+def read_stem_zc_image(path: Path) -> LoadedImage:
+    if path.suffix.lower() == ".dm3":
+        return _read_dm3_image(path)
+    return _read_tiff_image(path)
+
+
+def is_supported_2d_image(image: np.ndarray) -> bool:
+    return image.ndim == 2
+
+
+def _read_tiff_image(path: Path) -> LoadedImage:
+    with tifffile.TiffFile(path) as tiff:
+        if len(tiff.pages) != 1:
+            return LoadedImage(image=np.asarray([]))
+        page = tiff.pages[0]
+        image = tiff.asarray()
+        metadata_nm_per_px = _metadata_nm_per_px_from_tiff_page(page)
+
+    if (
+        image.ndim == 3
+        and image.shape[-1] in (3, 4)
+        and page.samplesperpixel in (3, 4)
+    ):
+        image = _to_grayscale(image)
+    return LoadedImage(image=image, metadata_nm_per_px=metadata_nm_per_px)
+
+
+def _metadata_nm_per_px_from_tiff_page(page: tifffile.TiffPage) -> float | None:
+    try:
+        resolution_unit = int(page.tags["ResolutionUnit"].value)
+        x_resolution = _ratio_to_float(page.tags["XResolution"].value)
+        y_resolution = _ratio_to_float(page.tags["YResolution"].value)
+    except (KeyError, TypeError, ValueError, ZeroDivisionError):
+        return None
+
+    if x_resolution <= 0 or y_resolution <= 0:
+        return None
+    if not np.allclose([x_resolution, y_resolution], x_resolution):
+        return None
+
+    if resolution_unit == 2:
+        nm_per_unit = 25_400_000.0
+    elif resolution_unit == 3:
+        nm_per_unit = 10_000_000.0
+    else:
+        return None
+    return nm_per_unit / x_resolution
+
+
+def _ratio_to_float(value: object) -> float:
+    if isinstance(value, tuple) and len(value) == 2:
+        numerator, denominator = value
+        return float(numerator) / float(denominator)
+    return float(value)
+
+
+def _read_dm3_image(path: Path) -> LoadedImage:
+    from rsciio import digitalmicrograph
+
+    signals = digitalmicrograph.file_reader(str(path))
+    if len(signals) == 0:
+        return LoadedImage(image=np.asarray([]))
+
+    signal = signals[0]
+    image = np.asarray(signal["data"])
+    return LoadedImage(
+        image=image,
+        metadata_nm_per_px=_metadata_nm_per_px_from_axes(signal.get("axes", [])),
+    )
+
+
+def _metadata_nm_per_px_from_axes(axes: object) -> float | None:
+    if not isinstance(axes, list):
+        return None
+
+    nm_scales: list[float] = []
+    for axis in axes:
+        if not isinstance(axis, dict):
+            continue
+        units = str(axis.get("units", "")).strip().lower()
+        if units not in {"nm", "nanometer", "nanometers"}:
+            continue
+        try:
+            scale = float(axis["scale"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if scale > 0:
+            nm_scales.append(scale)
+
+    if len(nm_scales) < 2:
+        return None
+    if not np.allclose(nm_scales, nm_scales[0]):
+        return None
+    return nm_scales[0]
+
+
+def _to_grayscale(image: np.ndarray) -> np.ndarray:
+    channels = image[..., :3].astype(np.float32)
+    grayscale = (
+        channels[..., 0] * 0.299
+        + channels[..., 1] * 0.587
+        + channels[..., 2] * 0.114
+    )
+    return np.rint(grayscale).astype(image.dtype)

--- a/src/measurer/image_queue.py
+++ b/src/measurer/image_queue.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import numpy as np
-import tifffile
 
+from measurer.image_input import is_supported_2d_image, read_stem_zc_image
 from measurer.roi import (
     PolygonRoi,
     RectRoi,
@@ -21,12 +21,6 @@ from measurer.roi import (
 class ScaleResolution:
     source: str
     nm_per_px: float | None
-
-
-@dataclass(frozen=True)
-class LoadedImage:
-    image: np.ndarray
-    metadata_nm_per_px: float | None = None
 
 
 @dataclass(frozen=True)
@@ -86,12 +80,12 @@ class ImageQueue:
                 continue
 
             try:
-                loaded_image = _read_image(path)
+                loaded_image = read_stem_zc_image(path)
             except Exception:
                 _count_skip(skipped_reasons, "failed to read image data")
                 continue
 
-            if not _is_supported_2d_image(loaded_image.image):
+            if not is_supported_2d_image(loaded_image.image):
                 _count_skip(skipped_reasons, "unsupported image shape")
                 continue
 
@@ -325,112 +319,6 @@ class ImageQueue:
             measurement_debug=None,
         )
         return True
-
-
-def _read_image(path: Path) -> LoadedImage:
-    if path.suffix.lower() == ".dm3":
-        return _read_dm3_image(path)
-    return _read_tiff_image(path)
-
-
-def _read_tiff_image(path: Path) -> LoadedImage:
-    with tifffile.TiffFile(path) as tiff:
-        if len(tiff.pages) != 1:
-            return LoadedImage(image=np.asarray([]))
-        page = tiff.pages[0]
-        image = tiff.asarray()
-        metadata_nm_per_px = _metadata_nm_per_px_from_tiff_page(page)
-
-    if (
-        image.ndim == 3
-        and image.shape[-1] in (3, 4)
-        and page.samplesperpixel in (3, 4)
-    ):
-        image = _to_grayscale(image)
-    return LoadedImage(image=image, metadata_nm_per_px=metadata_nm_per_px)
-
-
-def _metadata_nm_per_px_from_tiff_page(page: tifffile.TiffPage) -> float | None:
-    try:
-        resolution_unit = int(page.tags["ResolutionUnit"].value)
-        x_resolution = _ratio_to_float(page.tags["XResolution"].value)
-        y_resolution = _ratio_to_float(page.tags["YResolution"].value)
-    except (KeyError, TypeError, ValueError, ZeroDivisionError):
-        return None
-
-    if x_resolution <= 0 or y_resolution <= 0:
-        return None
-    if not np.allclose([x_resolution, y_resolution], x_resolution):
-        return None
-
-    if resolution_unit == 2:
-        nm_per_unit = 25_400_000.0
-    elif resolution_unit == 3:
-        nm_per_unit = 10_000_000.0
-    else:
-        return None
-    return nm_per_unit / x_resolution
-
-
-def _ratio_to_float(value: object) -> float:
-    if isinstance(value, tuple) and len(value) == 2:
-        numerator, denominator = value
-        return float(numerator) / float(denominator)
-    return float(value)
-
-
-def _read_dm3_image(path: Path) -> LoadedImage:
-    from rsciio import digitalmicrograph
-
-    signals = digitalmicrograph.file_reader(str(path))
-    if len(signals) == 0:
-        return LoadedImage(image=np.asarray([]))
-
-    signal = signals[0]
-    image = np.asarray(signal["data"])
-    return LoadedImage(
-        image=image,
-        metadata_nm_per_px=_metadata_nm_per_px_from_axes(signal.get("axes", [])),
-    )
-
-
-def _metadata_nm_per_px_from_axes(axes: object) -> float | None:
-    if not isinstance(axes, list):
-        return None
-
-    nm_scales: list[float] = []
-    for axis in axes:
-        if not isinstance(axis, dict):
-            continue
-        units = str(axis.get("units", "")).strip().lower()
-        if units not in {"nm", "nanometer", "nanometers"}:
-            continue
-        try:
-            scale = float(axis["scale"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        if scale > 0:
-            nm_scales.append(scale)
-
-    if len(nm_scales) < 2:
-        return None
-    if not np.allclose(nm_scales, nm_scales[0]):
-        return None
-    return nm_scales[0]
-
-
-def _is_supported_2d_image(image: np.ndarray) -> bool:
-    return image.ndim == 2
-
-
-def _to_grayscale(image: np.ndarray) -> np.ndarray:
-    channels = image[..., :3].astype(np.float32)
-    grayscale = (
-        channels[..., 0] * 0.299
-        + channels[..., 1] * 0.587
-        + channels[..., 2] * 0.114
-    )
-    return np.rint(grayscale).astype(image.dtype)
 
 
 def _count_skip(skipped_reasons: dict[str, int], reason: str) -> None:

--- a/src/measurer/result_render.py
+++ b/src/measurer/result_render.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import numpy as np
+from PySide6.QtGui import QColor, QImage, QPainter, QPen
+
+from measurer.image_display import normalize_to_uint8
+from measurer.measurement import MeasurementResult
+from measurer.measurement_report import successful_measurement_report_items
+
+
+def grayscale_rgb_qimage(image: np.ndarray) -> QImage:
+    display = normalize_to_uint8(image)
+    height, width = display.shape
+    rgb = np.ascontiguousarray(np.dstack([display, display, display]))
+    return QImage(
+        rgb.data,
+        width,
+        height,
+        width * 3,
+        QImage.Format.Format_RGB888,
+    ).copy()
+
+
+def result_qimage(
+    image: np.ndarray,
+    result: MeasurementResult,
+    nm_per_px: float | None,
+) -> QImage:
+    qimage = grayscale_rgb_qimage(image)
+    painter = QPainter(qimage)
+    draw_result_measurement_lines(painter, result, nm_per_px)
+    painter.end()
+    return qimage
+
+
+def draw_result_measurement_lines(
+    painter: QPainter,
+    result: MeasurementResult,
+    nm_per_px: float | None,
+) -> None:
+    for item in successful_measurement_report_items(result, nm_per_px):
+        measurement = item.measurement
+        painter.setPen(QPen(QColor(*item.color_rgb), 2))
+        painter.drawLine(
+            measurement.line.start.x,
+            measurement.line.start.y,
+            measurement.line.end.x,
+            measurement.line.end.y,
+        )
+        painter.setPen(QPen(QColor(245, 248, 252), 1))
+        painter.drawText(
+            round((measurement.line.start.x + measurement.line.end.x) / 2),
+            round((measurement.line.start.y + measurement.line.end.y) / 2),
+            item.label,
+        )

--- a/src/measurer/trace_sheet.py
+++ b/src/measurer/trace_sheet.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from measurer.measurement import Measurement, MeasurementResult
+from measurer.roi import RoiSelection
+
+
+TRACE_SHEET_HEADER = [
+    "file",
+    "group",
+    "measurement type",
+    "target ID",
+    "status",
+    "reason",
+    "value_px",
+    "x1_px",
+    "y1_px",
+    "x2_px",
+    "y2_px",
+    "scale_nm_per_px",
+    "scale_source",
+    "roi_type",
+    "roi_x_px",
+    "roi_y_px",
+    "roi_width_px",
+    "roi_height_px",
+    "roi_shape_count",
+    "refined_point_count",
+    "fallback_point_count",
+    "fallback_ratio",
+]
+
+
+def trace_sheet_row(
+    *,
+    file_name: str,
+    group: str,
+    measurement: Measurement,
+    measurement_type: str,
+    target_id: str,
+    result: MeasurementResult,
+    scale_source: str,
+    scale_nm_per_px: float | None,
+    roi: RoiSelection,
+) -> list[object]:
+    analysis_region = result.analysis_region
+    refined_count, fallback_count, fallback_ratio = _refinement_summary(
+        result, target_id
+    )
+    return [
+        file_name,
+        group,
+        measurement_type,
+        target_id,
+        measurement.status,
+        measurement.failure_reason,
+        measurement.value_px if measurement.status == "success" else None,
+        measurement.line.start.x,
+        measurement.line.start.y,
+        measurement.line.end.x,
+        measurement.line.end.y,
+        scale_nm_per_px,
+        scale_source,
+        _roi_type(roi),
+        analysis_region.x,
+        analysis_region.y,
+        analysis_region.width,
+        analysis_region.height,
+        _roi_shape_count(roi),
+        refined_count,
+        fallback_count,
+        fallback_ratio,
+    ]
+
+
+def _roi_type(roi: RoiSelection) -> str:
+    if roi.is_empty:
+        return "full_image"
+    return "union"
+
+
+def _roi_shape_count(roi: RoiSelection) -> int:
+    return len(roi.rectangles) + len(roi.polygons)
+
+
+def _refinement_summary(
+    result: MeasurementResult, target_id: str
+) -> tuple[int, int, float | None]:
+    if not result.metal_islands:
+        refined = result.refined_boundary.refined_point_count
+        fallback = result.refined_boundary.fallback_point_count
+        return refined, fallback, _fallback_ratio(refined, fallback)
+
+    target_ids = target_id.split("-")
+    boundaries = [
+        metal.refined_boundary
+        for metal in result.metal_islands
+        if metal.id in target_ids
+    ]
+    if not boundaries and result.metal_islands:
+        boundaries = [result.metal_islands[0].refined_boundary]
+
+    refined = sum(boundary.refined_point_count for boundary in boundaries)
+    fallback = sum(boundary.fallback_point_count for boundary in boundaries)
+    return refined, fallback, _fallback_ratio(refined, fallback)
+
+
+def _fallback_ratio(refined_count: int, fallback_count: int) -> float | None:
+    total = refined_count + fallback_count
+    if total == 0:
+        return None
+    return fallback_count / total

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -1,0 +1,50 @@
+import numpy as np
+import tifffile
+
+from measurer.image_input import is_supported_2d_image, read_stem_zc_image
+
+
+def test_read_stem_zc_image_reads_tiff_metadata_scale(tmp_path):
+    image_path = tmp_path / "metadata_scale.tif"
+    image = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    nm_per_px = 0.8
+    pixels_per_cm = 10_000_000 / nm_per_px
+    tifffile.imwrite(
+        image_path,
+        image,
+        resolution=(pixels_per_cm, pixels_per_cm),
+        resolutionunit="CENTIMETER",
+    )
+
+    loaded = read_stem_zc_image(image_path)
+
+    assert np.array_equal(loaded.image, image)
+    assert loaded.metadata_nm_per_px == 0.8
+    assert is_supported_2d_image(loaded.image)
+
+
+def test_read_stem_zc_image_reads_dm3_metadata_scale(monkeypatch, tmp_path):
+    image_path = tmp_path / "metadata_scale.dm3"
+    image_path.write_bytes(b"fake dm3")
+    image = np.ones((4, 4), dtype=np.uint8)
+
+    def fake_file_reader(filename):
+        return [
+            {
+                "data": image,
+                "axes": [
+                    {"name": "y", "scale": 0.8, "units": "nm"},
+                    {"name": "x", "scale": 0.8, "units": "nm"},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "rsciio.digitalmicrograph.file_reader",
+        fake_file_reader,
+    )
+
+    loaded = read_stem_zc_image(image_path)
+
+    assert np.array_equal(loaded.image, image)
+    assert loaded.metadata_nm_per_px == 0.8

--- a/tests/test_trace_sheet.py
+++ b/tests/test_trace_sheet.py
@@ -1,0 +1,107 @@
+import pytest
+
+from measurer.measurement import measure_image
+from measurer.roi import RectRoi, RoiSelection
+from measurer.synthetic import SingleMetalIslandSpec, create_single_metal_island_image
+from measurer.trace_sheet import TRACE_SHEET_HEADER, trace_sheet_row
+
+
+def test_trace_sheet_row_records_roi_union_metadata():
+    image = create_single_metal_island_image(
+        SingleMetalIslandSpec(
+            image_width=128,
+            image_height=128,
+            center_x=64,
+            top_y=24,
+            height=60,
+            tcd=32,
+            bcd=48,
+        )
+    )
+    roi = RoiSelection(
+        (
+            RectRoi(x=32, y=16, width=64, height=80),
+            RectRoi(x=96, y=96, width=24, height=24),
+        )
+    )
+    result = measure_image(image, roi=roi)
+
+    row = trace_sheet_row(
+        file_name="roi.tif",
+        group="Process A",
+        measurement=result.measurements["TCD"],
+        measurement_type="TCD",
+        target_id="Image",
+        result=result,
+        scale_source="manual_default",
+        scale_nm_per_px=0.5,
+        roi=roi,
+    )
+    values = dict(zip(TRACE_SHEET_HEADER, row, strict=True))
+
+    assert values["file"] == "roi.tif"
+    assert values["group"] == "Process A"
+    assert values["scale_nm_per_px"] == 0.5
+    assert values["scale_source"] == "manual_default"
+    assert values["roi_type"] == "union"
+    assert values["roi_x_px"] == 32
+    assert values["roi_y_px"] == 16
+    assert values["roi_width_px"] == 88
+    assert values["roi_height_px"] == 104
+    assert values["roi_shape_count"] == 2
+
+
+def test_trace_sheet_row_summarizes_space_pair_refined_boundaries():
+    image = create_single_metal_island_image(
+        SingleMetalIslandSpec(
+            image_width=220,
+            image_height=128,
+            center_x=60,
+            top_y=24,
+            height=60,
+            tcd=30,
+            bcd=42,
+        )
+    )
+    right_image = create_single_metal_island_image(
+        SingleMetalIslandSpec(
+            image_width=220,
+            image_height=128,
+            center_x=150,
+            top_y=24,
+            height=60,
+            tcd=30,
+            bcd=42,
+        )
+    )
+    image = image.copy()
+    image[right_image == 220] = 220
+    result = measure_image(image, roi=None)
+    measurement = result.measurements["M001-M002 Horizontal Space"]
+
+    row = trace_sheet_row(
+        file_name="space.tif",
+        group="Default",
+        measurement=measurement,
+        measurement_type="Horizontal Space",
+        target_id="M001-M002",
+        result=result,
+        scale_source="px",
+        scale_nm_per_px=None,
+        roi=RoiSelection(),
+    )
+    values = dict(zip(TRACE_SHEET_HEADER, row, strict=True))
+    expected_refined = sum(
+        metal.refined_boundary.refined_point_count
+        for metal in result.metal_islands
+    )
+    expected_fallback = sum(
+        metal.refined_boundary.fallback_point_count
+        for metal in result.metal_islands
+    )
+
+    assert values["roi_type"] == "full_image"
+    assert values["roi_shape_count"] == 0
+    assert values["refined_point_count"] == expected_refined
+    assert values["fallback_point_count"] == expected_fallback
+    assert values["fallback_ratio"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- Extracted shared Result Image and Debug View / Debug Image rendering modules.
- Extracted STEM ZC Image input parsing into `image_input.py`.
- Extracted Trace Sheet schema and row construction into `trace_sheet.py`.
- Added focused tests for image input and Trace Sheet behavior.
- Updated README as the source of truth for the new architecture.

## Why

The previous implementation kept image input parsing, diagnostic rendering, exported Result Image rendering, and Trace Sheet interpretation inside broad orchestration modules. This made `app.py`, `export.py`, and `image_queue.py` harder to navigate and increased the chance of GUI and export behavior drifting apart.

## Validation

- `uv run pytest` -> 130 passed
- `uv run python -m compileall src/measurer tests` -> passed